### PR TITLE
Add ci-operator build root configuration file

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.16-openshift-4.10


### PR DESCRIPTION
This file is required to use the `build_root` from repository configuration defined in the github/openshift/release/tree/master/ci-operator/config/openshift/image-customization-controller repo