### PR TITLE
Bind mount DBus socket in IPA container

### DIFF
--- a/pkg/ignition/service_config.go
+++ b/pkg/ignition/service_config.go
@@ -37,7 +37,7 @@ Wants=network-online.target
 [Service]
 TimeoutStartSec=0
 ExecStartPre=/bin/podman pull %s %s
-ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent %s
+ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent %s
 [Install]
 WantedBy=multi-user.target
 `

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -55,7 +55,7 @@ func TestIronicAgentService(t *testing.T) {
 			want: ignition_config_types_32.Unit{
 				Name:     "ironic-agent.service",
 				Enabled:  pointer.BoolPtr(true),
-				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
+				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
 			},
 		}}
 	for _, tt := range tests {


### PR DESCRIPTION
This is required to run nmstate from the container, which we need to do
to apply network config at provision time.