### PR TITLE
Support serving a customised initramfs

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -133,7 +133,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	imageServer := imagehandler.NewImageHandler(ctrl.Log.WithName("ImageHandler"), envInputs.DeployISO, imagesPublishAddr)
+	imageServer := imagehandler.NewImageHandler(ctrl.Log.WithName("ImageHandler"), envInputs.DeployISO, envInputs.DeployInitrd, imagesPublishAddr)
 	http.Handle("/", http.FileServer(imageServer.FileSystem()))
 
 	go func() {

--- a/cmd/static-server/main.go
+++ b/cmd/static-server/main.go
@@ -86,7 +86,7 @@ func loadStaticNMState(env *env.EnvInputs, nmstateDir string, imageServer imageh
 			log.Info("image mapping not available, using image", "name", imageName)
 		}
 
-		url, err := imageServer.ServeImage(imageName, ign)
+		url, err := imageServer.ServeImage(imageName, ign, false)
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	imageServer := imagehandler.NewImageHandler(ctrl.Log.WithName("ImageHandler"), env.DeployISO, imagesPublishAddr)
+	imageServer := imagehandler.NewImageHandler(ctrl.Log.WithName("ImageHandler"), env.DeployISO, env.DeployInitrd, imagesPublishAddr)
 	http.Handle("/", http.FileServer(imageServer.FileSystem()))
 
 	if err := loadStaticNMState(env, nmstateDir, imageServer); err != nil {

--- a/cmd/static-server/main_test.go
+++ b/cmd/static-server/main_test.go
@@ -41,7 +41,7 @@ func (f *fakeImageFileSystem) Seek(offset int64, whence int) (int64, error) { re
 func (f *fakeImageFileSystem) Readdir(n int) ([]fs.FileInfo, error)         { return nil, nil }
 func (f *fakeImageFileSystem) Open(name string) (http.File, error)          { return nil, nil }
 func (f *fakeImageFileSystem) FileSystem() http.FileSystem                  { return f }
-func (f *fakeImageFileSystem) ServeImage(name string, ignitionContent []byte) (string, error) {
+func (f *fakeImageFileSystem) ServeImage(name string, ignitionContent []byte, initrd bool) (string, error) {
 	f.imagesServed = append(f.imagesServed, name)
 	return "", nil
 }

--- a/controllers/metal3.io/preprovisioningimage_controller.go
+++ b/controllers/metal3.io/preprovisioningimage_controller.go
@@ -115,7 +115,7 @@ func (r *PreprovisioningImageReconciler) reconcile(ctx context.Context, img *met
 	format := metal3.ImageFormatISO
 	imageName := img.Name + "." + string(format)
 
-	url, err := r.ImageHandler.ServeImage(imageName, ignitionConfig)
+	url, err := r.ImageHandler.ServeImage(imageName, ignitionConfig, false)
 	if err != nil {
 		return setError(ctx, generation, &img.Status, reasonImageServingError, err.Error()), err
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/metal3-io/baremetal-operator v0.0.0-00010101000000-000000000000
 	github.com/metal3-io/baremetal-operator/apis v0.0.0
-	github.com/openshift/assisted-image-service v0.0.0-20211012141310-4010348b8e14
+	github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2
 	github.com/pkg/errors v0.9.1
 	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
 	k8s.io/api v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/openshift/assisted-image-service v0.0.0-20211012141310-4010348b8e14 h1:NlkZmFhN7GJVEgBcwmhzVhGZjWMK40Nq7scKfaeP7nc=
-github.com/openshift/assisted-image-service v0.0.0-20211012141310-4010348b8e14/go.mod h1:/IQ+1G8uT5P/YW9YUi1SBAbxulmlpPAA6rI/KEHmqfQ=
+github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2 h1:+gcwjGhbLdWtfpDIikhDO7FN7Lx2Uhx5HktPjP5GwEo=
+github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2/go.mod h1:DSFZEsQZpIHqnV9saugs7meqdYmGKlI5FKKkDe421/g=
 github.com/openshift/baremetal-operator v0.0.0-20211116121852-fffb8279f132 h1:2jAZkUdiESTQRlW0h/QIyHKR3npd3UjsPJQIIwArqnM=
 github.com/openshift/baremetal-operator v0.0.0-20211116121852-fffb8279f132/go.mod h1:jcHrkDEev1N4uTA4TjwoiU5/llljPZRU3ijBsYQ1Ddk=
 github.com/openshift/baremetal-operator/apis v0.0.0-20211116121852-fffb8279f132 h1:Yd6mf/Vanok5otqyODCuLfFJD5BsI+24/7xxxgyjiio=
@@ -653,6 +653,7 @@ github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2 h1:Xr9gkxfOP0K
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tetafro/godot v0.4.9 h1:dSOiuasshpevY73eeI3+zaqFnXSBKJ3mvxbyhh54VRo=
 github.com/tetafro/godot v0.4.9/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
+github.com/thoas/go-funk v0.9.1/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e h1:RumXZ56IrCj4CL+g1b9OL/oH0QnsF976bC8xQFYUD5Q=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -4,6 +4,7 @@ import "github.com/kelseyhightower/envconfig"
 
 type EnvInputs struct {
 	DeployISO             string `envconfig:"DEPLOY_ISO" required:"true"`
+	DeployInitrd          string `envconfig:"DEPLOY_INITRD" required:"true"`
 	IronicBaseURL         string `envconfig:"IRONIC_BASE_URL" required:"true"`
 	IronicAgentImage      string `envconfig:"IRONIC_AGENT_IMAGE"`
 	IronicAgentPullSecret string `envconfig:"IRONIC_AGENT_PULL_SECRET"`

--- a/pkg/imagehandler/basefile.go
+++ b/pkg/imagehandler/basefile.go
@@ -39,3 +39,15 @@ func newBaseIso(filename string) *baseIso {
 func (biso *baseIso) InsertIgnition(ignition *isoeditor.IgnitionContent) (io.ReadSeeker, error) {
 	return isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil)
 }
+
+type baseInitramfs struct {
+	baseFileData
+}
+
+func newBaseInitramfs(filename string) *baseInitramfs {
+	return &baseInitramfs{baseFileData{filename: filename}}
+}
+
+func (birfs *baseInitramfs) InsertIgnition(ignition *isoeditor.IgnitionContent) (io.ReadSeeker, error) {
+	return isoeditor.NewInitRamFSStreamReader(birfs.filename, ignition)
+}

--- a/pkg/imagehandler/basefile.go
+++ b/pkg/imagehandler/basefile.go
@@ -1,0 +1,41 @@
+package imagehandler
+
+import (
+	"io"
+	"os"
+
+	"github.com/openshift/assisted-image-service/pkg/isoeditor"
+)
+
+type baseFile interface {
+	Size() (int64, error)
+	InsertIgnition(*isoeditor.IgnitionContent) (io.ReadSeeker, error)
+}
+
+type baseFileData struct {
+	filename string
+	size     int64
+}
+
+func (bf *baseFileData) Size() (int64, error) {
+	if bf.size == 0 {
+		fi, err := os.Stat(bf.filename)
+		if err != nil {
+			return 0, err
+		}
+		bf.size = fi.Size()
+	}
+	return bf.size, nil
+}
+
+type baseIso struct {
+	baseFileData
+}
+
+func newBaseIso(filename string) *baseIso {
+	return &baseIso{baseFileData{filename: filename}}
+}
+
+func (biso *baseIso) InsertIgnition(ignition *isoeditor.IgnitionContent) (io.ReadSeeker, error) {
+	return isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil)
+}

--- a/pkg/imagehandler/imagefile.go
+++ b/pkg/imagehandler/imagefile.go
@@ -34,13 +34,12 @@ type imageFile struct {
 
 var _ fs.File = &imageFile{}
 
-func (f *imageFile) Init(isoFile string) error {
+func (f *imageFile) Init(isoFile baseFile) error {
 	if f.rhcosStreamReader == nil {
 		var err error
-		f.rhcosStreamReader, err = isoeditor.NewRHCOSStreamReader(
-			isoFile,
-			&isoeditor.IgnitionContent{Config: f.ignitionContent},
-			nil)
+
+		ignition := &isoeditor.IgnitionContent{Config: f.ignitionContent}
+		f.rhcosStreamReader, err = isoFile.InsertIgnition(ignition)
 		if err != nil {
 			return err
 		}

--- a/pkg/imagehandler/imagefile.go
+++ b/pkg/imagehandler/imagefile.go
@@ -28,6 +28,7 @@ type imageFile struct {
 	size              int64
 	ignitionContent   []byte
 	rhcosStreamReader io.ReadSeeker
+	initramfs         bool
 }
 
 // file interface implementation

--- a/pkg/imagehandler/imagefile.go
+++ b/pkg/imagehandler/imagefile.go
@@ -34,12 +34,11 @@ type imageFile struct {
 
 var _ fs.File = &imageFile{}
 
-func (f *imageFile) Init(isoFile baseFile) error {
+func (f *imageFile) Init(inputFile baseFile) error {
 	if f.rhcosStreamReader == nil {
 		var err error
-
 		ignition := &isoeditor.IgnitionContent{Config: f.ignitionContent}
-		f.rhcosStreamReader, err = isoFile.InsertIgnition(ignition)
+		f.rhcosStreamReader, err = inputFile.InsertIgnition(ignition)
 		if err != nil {
 			return err
 		}

--- a/pkg/imagehandler/imagefile.go
+++ b/pkg/imagehandler/imagefile.go
@@ -24,11 +24,11 @@ import (
 // imageFile is the http.File use in imageFileSystem.
 type imageFile struct {
 	io.ReadSeekCloser
-	name              string
-	size              int64
-	ignitionContent   []byte
-	rhcosStreamReader io.ReadSeeker
-	initramfs         bool
+	name            string
+	size            int64
+	ignitionContent []byte
+	imageReader     io.ReadSeeker
+	initramfs       bool
 }
 
 // file interface implementation
@@ -36,10 +36,10 @@ type imageFile struct {
 var _ fs.File = &imageFile{}
 
 func (f *imageFile) Init(inputFile baseFile) error {
-	if f.rhcosStreamReader == nil {
+	if f.imageReader == nil {
 		var err error
 		ignition := &isoeditor.IgnitionContent{Config: f.ignitionContent}
-		f.rhcosStreamReader, err = inputFile.InsertIgnition(ignition)
+		f.imageReader, err = inputFile.InsertIgnition(ignition)
 		if err != nil {
 			return err
 		}
@@ -51,9 +51,9 @@ func (f *imageFile) Write(p []byte) (n int, err error)        { return 0, notImp
 func (f *imageFile) Stat() (fs.FileInfo, error)               { return fs.FileInfo(f), nil }
 func (f *imageFile) Close() error                             { return nil }
 func (f *imageFile) Readdir(count int) ([]fs.FileInfo, error) { return []fs.FileInfo{}, nil }
-func (f *imageFile) Read(p []byte) (n int, err error)         { return f.rhcosStreamReader.Read(p) }
+func (f *imageFile) Read(p []byte) (n int, err error)         { return f.imageReader.Read(p) }
 func (f *imageFile) Seek(offset int64, whence int) (int64, error) {
-	return f.rhcosStreamReader.Seek(offset, whence)
+	return f.imageReader.Seek(offset, whence)
 }
 
 // fileInfo interface implementation

--- a/pkg/imagehandler/imagefile.go
+++ b/pkg/imagehandler/imagefile.go
@@ -17,6 +17,8 @@ import (
 	"io"
 	"io/fs"
 	"time"
+
+	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 )
 
 // imageFile is the http.File use in imageFileSystem.
@@ -31,6 +33,20 @@ type imageFile struct {
 // file interface implementation
 
 var _ fs.File = &imageFile{}
+
+func (f *imageFile) Init(isoFile string) error {
+	if f.rhcosStreamReader == nil {
+		var err error
+		f.rhcosStreamReader, err = isoeditor.NewRHCOSStreamReader(
+			isoFile,
+			&isoeditor.IgnitionContent{Config: f.ignitionContent},
+			nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 func (f *imageFile) Write(p []byte) (n int, err error)        { return 0, notImplementedFn("Write") }
 func (f *imageFile) Stat() (fs.FileInfo, error)               { return fs.FileInfo(f), nil }

--- a/pkg/imagehandler/imagefilesystem.go
+++ b/pkg/imagehandler/imagefilesystem.go
@@ -19,8 +19,6 @@ import (
 	"net/http"
 	"path"
 	"time"
-
-	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 )
 
 func notImplementedFn(name string) error { return fmt.Errorf("%s not implemented", name) }
@@ -58,13 +56,9 @@ func (f *imageFileSystem) Open(name string) (http.File, error) {
 	if im == nil {
 		return nil, fs.ErrNotExist
 	}
-	if im.rhcosStreamReader == nil {
-		var err error
-		im.rhcosStreamReader, err = isoeditor.NewRHCOSStreamReader(f.isoFile, &isoeditor.IgnitionContent{Config: im.ignitionContent}, nil)
-		if err != nil {
-			f.log.Error(err, "creating isoeditor.NewRHCOSStreamReader")
-			return nil, err
-		}
+	if err := im.Init(f.isoFile); err != nil {
+		f.log.Error(err, "failed to create image stream")
+		return nil, err
 	}
 	return im, nil
 }

--- a/pkg/imagehandler/imagefilesystem.go
+++ b/pkg/imagehandler/imagefilesystem.go
@@ -56,7 +56,7 @@ func (f *imageFileSystem) Open(name string) (http.File, error) {
 	if im == nil {
 		return nil, fs.ErrNotExist
 	}
-	if err := im.Init(f.isoFile); err != nil {
+	if err := im.Init(f.getBaseImage(im.initramfs)); err != nil {
 		f.log.Error(err, "failed to create image stream")
 		return nil, err
 	}

--- a/pkg/imagehandler/imagehandler_test.go
+++ b/pkg/imagehandler/imagehandler_test.go
@@ -36,10 +36,10 @@ func TestImageHandler(t *testing.T) {
 		baseURL: "http://localhost:8080",
 		images: []*imageFile{
 			{
-				name:              "host-xyz-45.iso",
-				size:              12345,
-				ignitionContent:   []byte("asietonarst"),
-				rhcosStreamReader: strings.NewReader("aiosetnarsetin"),
+				name:            "host-xyz-45.iso",
+				size:            12345,
+				ignitionContent: []byte("asietonarst"),
+				imageReader:     strings.NewReader("aiosetnarsetin"),
 			},
 		},
 		mu: &sync.Mutex{},

--- a/pkg/imagehandler/imagehandler_test.go
+++ b/pkg/imagehandler/imagehandler_test.go
@@ -31,10 +31,9 @@ func TestImageHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	imageServer := &imageFileSystem{
-		log:         zap.New(zap.UseDevMode(true)),
-		isoFile:     "dummyfile.iso",
-		isoFileSize: 12345,
-		baseURL:     "http://localhost:8080",
+		log:     zap.New(zap.UseDevMode(true)),
+		isoFile: &baseIso{baseFileData{filename: "dummyfile.iso", size: 12345}},
+		baseURL: "http://localhost:8080",
 		images: []*imageFile{
 			{
 				name:              "host-xyz-45.iso",

--- a/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/initramfs.go
+++ b/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/initramfs.go
@@ -1,0 +1,27 @@
+package isoeditor
+
+import (
+	"io"
+	"os"
+
+	"github.com/openshift/assisted-image-service/pkg/overlay"
+	"github.com/pkg/errors"
+)
+
+func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (io.ReadSeeker, error) {
+	irfsReader, err := os.Open(irfsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ignitionReader, err := ignitionContent.Archive()
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := overlay.NewAppendReader(irfsReader, ignitionReader)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create append reader for ignition")
+	}
+	return r, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/nbutton23/zxcvbn-go/scoring
 github.com/nbutton23/zxcvbn-go/utils/math
 # github.com/nishanths/exhaustive v0.1.0
 github.com/nishanths/exhaustive
-# github.com/openshift/assisted-image-service v0.0.0-20211012141310-4010348b8e14
+# github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2
 ## explicit
 github.com/openshift/assisted-image-service/pkg/isoeditor
 github.com/openshift/assisted-image-service/pkg/overlay


### PR DESCRIPTION
Add code to customise an initramfs (instead of an ISO) and allow it to be served.

Note that there is no front-end interface to this yet.