### PR TITLE
Close the image stream after serving

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/metal3-io/baremetal-operator v0.0.0-00010101000000-000000000000
 	github.com/metal3-io/baremetal-operator/apis v0.0.0
-	github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2
+	github.com/openshift/assisted-image-service v0.0.0-20211122133112-1552361c0458
 	github.com/pkg/errors v0.9.1
 	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
 	k8s.io/api v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2 h1:+gcwjGhbLdWtfpDIikhDO7FN7Lx2Uhx5HktPjP5GwEo=
-github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2/go.mod h1:DSFZEsQZpIHqnV9saugs7meqdYmGKlI5FKKkDe421/g=
+github.com/openshift/assisted-image-service v0.0.0-20211122133112-1552361c0458 h1:TDYrQaxV3PObc4pmcft15BUCbuDe0UNhzXTDZGnvzZ0=
+github.com/openshift/assisted-image-service v0.0.0-20211122133112-1552361c0458/go.mod h1:DSFZEsQZpIHqnV9saugs7meqdYmGKlI5FKKkDe421/g=
 github.com/openshift/baremetal-operator v0.0.0-20211116121852-fffb8279f132 h1:2jAZkUdiESTQRlW0h/QIyHKR3npd3UjsPJQIIwArqnM=
 github.com/openshift/baremetal-operator v0.0.0-20211116121852-fffb8279f132/go.mod h1:jcHrkDEev1N4uTA4TjwoiU5/llljPZRU3ijBsYQ1Ddk=
 github.com/openshift/baremetal-operator/apis v0.0.0-20211116121852-fffb8279f132 h1:Yd6mf/Vanok5otqyODCuLfFJD5BsI+24/7xxxgyjiio=

--- a/pkg/imagehandler/basefile.go
+++ b/pkg/imagehandler/basefile.go
@@ -1,7 +1,6 @@
 package imagehandler
 
 import (
-	"io"
 	"os"
 
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
@@ -9,7 +8,7 @@ import (
 
 type baseFile interface {
 	Size() (int64, error)
-	InsertIgnition(*isoeditor.IgnitionContent) (io.ReadSeeker, error)
+	InsertIgnition(*isoeditor.IgnitionContent) (isoeditor.ImageReader, error)
 }
 
 type baseFileData struct {
@@ -36,7 +35,7 @@ func newBaseIso(filename string) *baseIso {
 	return &baseIso{baseFileData{filename: filename}}
 }
 
-func (biso *baseIso) InsertIgnition(ignition *isoeditor.IgnitionContent) (io.ReadSeeker, error) {
+func (biso *baseIso) InsertIgnition(ignition *isoeditor.IgnitionContent) (isoeditor.ImageReader, error) {
 	return isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil)
 }
 
@@ -48,6 +47,6 @@ func newBaseInitramfs(filename string) *baseInitramfs {
 	return &baseInitramfs{baseFileData{filename: filename}}
 }
 
-func (birfs *baseInitramfs) InsertIgnition(ignition *isoeditor.IgnitionContent) (io.ReadSeeker, error) {
+func (birfs *baseInitramfs) InsertIgnition(ignition *isoeditor.IgnitionContent) (isoeditor.ImageReader, error) {
 	return isoeditor.NewInitRamFSStreamReader(birfs.filename, ignition)
 }

--- a/pkg/imagehandler/imagefile.go
+++ b/pkg/imagehandler/imagefile.go
@@ -27,7 +27,7 @@ type imageFile struct {
 	name            string
 	size            int64
 	ignitionContent []byte
-	imageReader     io.ReadSeeker
+	imageReader     isoeditor.ImageReader
 	initramfs       bool
 }
 
@@ -47,9 +47,13 @@ func (f *imageFile) Init(inputFile baseFile) error {
 	return nil
 }
 
-func (f *imageFile) Write(p []byte) (n int, err error)        { return 0, notImplementedFn("Write") }
-func (f *imageFile) Stat() (fs.FileInfo, error)               { return fs.FileInfo(f), nil }
-func (f *imageFile) Close() error                             { return nil }
+func (f *imageFile) Write(p []byte) (n int, err error) { return 0, notImplementedFn("Write") }
+func (f *imageFile) Stat() (fs.FileInfo, error)        { return fs.FileInfo(f), nil }
+func (f *imageFile) Close() error {
+	err := f.imageReader.Close()
+	f.imageReader = nil
+	return err
+}
 func (f *imageFile) Readdir(count int) ([]fs.FileInfo, error) { return []fs.FileInfo{}, nil }
 func (f *imageFile) Read(p []byte) (n int, err error)         { return f.imageReader.Read(p) }
 func (f *imageFile) Seek(offset int64, whence int) (int64, error) {

--- a/pkg/imagehandler/imagehandler_test.go
+++ b/pkg/imagehandler/imagehandler_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package imagehandler
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -22,6 +23,18 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+type closer struct {
+	io.ReadSeeker
+}
+
+func (c closer) Close() error {
+	return nil
+}
+
+func nopCloser(stream io.ReadSeeker) io.ReadSeekCloser {
+	return closer{stream}
+}
 
 func TestImageHandler(t *testing.T) {
 	req, err := http.NewRequest("GET", "/host-xyz-45.iso", nil)
@@ -39,7 +52,7 @@ func TestImageHandler(t *testing.T) {
 				name:            "host-xyz-45.iso",
 				size:            12345,
 				ignitionContent: []byte("asietonarst"),
-				imageReader:     strings.NewReader("aiosetnarsetin"),
+				imageReader:     nopCloser(strings.NewReader("aiosetnarsetin")),
 			},
 		},
 		mu: &sync.Mutex{},

--- a/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/initramfs.go
+++ b/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/initramfs.go
@@ -1,14 +1,13 @@
 package isoeditor
 
 import (
-	"io"
 	"os"
 
 	"github.com/openshift/assisted-image-service/pkg/overlay"
 	"github.com/pkg/errors"
 )
 
-func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (io.ReadSeeker, error) {
+func NewInitRamFSStreamReader(irfsPath string, ignitionContent *IgnitionContent) (overlay.OverlayReader, error) {
 	irfsReader, err := os.Open(irfsPath)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/stream.go
+++ b/vendor/github.com/openshift/assisted-image-service/pkg/isoeditor/stream.go
@@ -12,9 +12,11 @@ import (
 
 const ignitionImagePath = "/images/ignition.img"
 
-type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (io.ReadSeeker, error)
+type ImageReader = overlay.OverlayReader
 
-func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (io.ReadSeeker, error) {
+type StreamGeneratorFunc func(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (ImageReader, error)
+
+func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramdiskContent []byte) (ImageReader, error) {
 	isoReader, err := os.Open(isoPath)
 	if err != nil {
 		return nil, err
@@ -40,7 +42,7 @@ func NewRHCOSStreamReader(isoPath string, ignitionContent *IgnitionContent, ramd
 	return r, nil
 }
 
-func readerForContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (io.ReadSeeker, error) {
+func readerForContent(isoPath string, filePath string, base io.ReadSeeker, contentReader *bytes.Reader) (overlay.OverlayReader, error) {
 	start, length, err := GetISOFileInfo(filePath, isoPath)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/openshift/assisted-image-service/pkg/overlay/overlay.go
+++ b/vendor/github.com/openshift/assisted-image-service/pkg/overlay/overlay.go
@@ -5,6 +5,13 @@ import (
 	"io"
 )
 
+type BaseStream = io.ReadSeeker
+
+type OverlayReader interface {
+	BaseStream
+	io.ReadSeekCloser
+}
+
 type Overlay struct {
 	Reader io.ReadSeeker
 	Offset int64
@@ -20,14 +27,14 @@ func (ol Overlay) contains(index int64) bool {
 }
 
 type overlayReader struct {
-	Base    io.ReadSeeker
+	Base    BaseStream
 	Overlay Overlay
 
 	readIndex   int64
 	totalLength int64
 }
 
-func newReader(base io.ReadSeeker, overlay Overlay, length int64) (*overlayReader, error) {
+func newReader(base BaseStream, overlay Overlay, length int64) (*overlayReader, error) {
 	if overlay.end() > length {
 		length = overlay.end()
 	}
@@ -48,7 +55,7 @@ func newReader(base io.ReadSeeker, overlay Overlay, length int64) (*overlayReade
 	return &or, nil
 }
 
-func NewOverlayReader(base io.ReadSeeker, overlay Overlay) (io.ReadSeeker, error) {
+func NewOverlayReader(base BaseStream, overlay Overlay) (OverlayReader, error) {
 	length, err := base.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, err
@@ -59,7 +66,7 @@ func NewOverlayReader(base io.ReadSeeker, overlay Overlay) (io.ReadSeeker, error
 	return newReader(base, overlay, length)
 }
 
-func NewAppendReader(base io.ReadSeeker, reader io.ReadSeeker) (io.ReadSeeker, error) {
+func NewAppendReader(base BaseStream, reader io.ReadSeeker) (OverlayReader, error) {
 	length, err := base.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, err
@@ -140,4 +147,11 @@ func (or *overlayReader) Read(p []byte) (int, error) {
 		return bytesRead, readErr
 	}
 	return bytesRead, seekErr
+}
+
+func (or *overlayReader) Close() error {
+	if closer, hasClose := or.Base.(io.Closer); hasClose {
+		return closer.Close()
+	}
+	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,7 +267,7 @@ github.com/nbutton23/zxcvbn-go/scoring
 github.com/nbutton23/zxcvbn-go/utils/math
 # github.com/nishanths/exhaustive v0.1.0
 github.com/nishanths/exhaustive
-# github.com/openshift/assisted-image-service v0.0.0-20211117195230-cdcb2b829ab2
+# github.com/openshift/assisted-image-service v0.0.0-20211122133112-1552361c0458
 ## explicit
 github.com/openshift/assisted-image-service/pkg/isoeditor
 github.com/openshift/assisted-image-service/pkg/overlay


### PR DESCRIPTION
This should prevent any memory/file descriptor leaks from keeping the streams open.