### PR TITLE
Do not set GOOS/GOARCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS builder
 WORKDIR /go/src/github.com/openshift/image-customization-controller
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o bin/image-customization-controller cmd/controller/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=mod -a -o bin/image-customization-server cmd/static-server/main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=mod -a -o bin/image-customization-controller cmd/controller/main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=mod -a -o bin/image-customization-server cmd/static-server/main.go
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/image-customization-controller/bin/image-customization-controller /


### PR DESCRIPTION
golang compiles natively by default; these variables only need to be set when cross-compiling. Setting these here would result in non-functional multi-arch builds.