### PR TITLE
Support embedding a custom registries.conf file

### DIFF
--- a/cmd/static-server/main.go
+++ b/cmd/static-server/main.go
@@ -40,6 +40,11 @@ var (
 )
 
 func loadStaticNMState(env *env.EnvInputs, nmstateDir string, imageServer imagehandler.ImageHandler) error {
+	registries, err := env.RegistriesConf()
+	if err != nil {
+		return err
+	}
+
 	files, err := ioutil.ReadDir(nmstateDir)
 	if err != nil {
 		return errors.WithMessagef(err, "problem reading %s", nmstateDir)
@@ -53,7 +58,7 @@ func loadStaticNMState(env *env.EnvInputs, nmstateDir string, imageServer imageh
 		if err != nil {
 			return errors.WithMessagef(err, "problem reading %s", path.Join(nmstateDir, f.Name()))
 		}
-		igBuilder := ignition.New(b,
+		igBuilder := ignition.New(b, registries,
 			env.IronicBaseURL,
 			env.IronicAgentImage,
 			env.IronicAgentPullSecret,

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,6 +1,11 @@
 package env
 
-import "github.com/kelseyhightower/envconfig"
+import (
+	"os"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/pkg/errors"
+)
 
 type EnvInputs struct {
 	DeployISO             string `envconfig:"DEPLOY_ISO" required:"true"`
@@ -9,10 +14,24 @@ type EnvInputs struct {
 	IronicAgentImage      string `envconfig:"IRONIC_AGENT_IMAGE"`
 	IronicAgentPullSecret string `envconfig:"IRONIC_AGENT_PULL_SECRET"`
 	IronicRAMDiskSSHKey   string `envconfig:"IRONIC_RAMDISK_SSH_KEY"`
+	RegistriesConfPath    string `envconfig:"REGISTRIES_CONF_PATH"`
 }
 
 func New() (*EnvInputs, error) {
 	env := &EnvInputs{}
 	err := envconfig.Process("", env)
 	return env, err
+}
+
+func (env *EnvInputs) RegistriesConf() (data []byte, err error) {
+	if env.RegistriesConfPath == "" {
+		return
+	}
+
+	data, err = os.ReadFile(env.RegistriesConfPath)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to read registries.conf file %s",
+			env.RegistriesConfPath)
+	}
+	return
 }

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,29 @@
+package env
+
+import (
+	"testing"
+)
+
+func TestRegistriesConf(t *testing.T) {
+	inputs := EnvInputs{
+		RegistriesConfPath: "../../test/registries.conf",
+	}
+
+	registries := `[[registry]]
+  prefix = ""
+  location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+  mirror-by-digest-only = true
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+`
+
+	data, err := inputs.RegistriesConf()
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	if string(data) != registries {
+		t.Fatalf("Registries data:\n%s\ndoes not match expected:\n%s", string(data), registries)
+	}
+}

--- a/pkg/ignition/builder_test.go
+++ b/pkg/ignition/builder_test.go
@@ -1,0 +1,32 @@
+package ignition
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateRegistries(t *testing.T) {
+	registries := `
+[[registry]]
+  prefix = ""
+  location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+  mirror-by-digest-only = true
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
+`
+	builder := New([]byte{}, []byte(registries),
+		"http://ironic.example.com",
+		"quay.io/openshift-release-dev/ironic-ipa-image",
+		"", "")
+
+	ignition, err := builder.Generate()
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+
+	registriesData := "\"data:text/plain,%0A%5B%5Bregistry%5D%5D%0A%20%20prefix%20%3D%20%22%22%0A%20%20location%20%3D%20%22quay.io%2Fopenshift-release-dev%2Focp-v4.0-art-dev%22%0A%20%20mirror-by-digest-only%20%3D%20true%0A%0A%20%20%5B%5Bregistry.mirror%5D%5D%0A%20%20%20%20location%20%3D%20%22virthost.ostest.test.metalkube.org%3A5000%2Flocalimages%2Flocal-release-image%22%0A\""
+	if !strings.Contains(string(ignition), registriesData) {
+		t.Fatalf("Registries data not found in ignition:\n%s", string(ignition))
+	}
+}

--- a/pkg/imageprovider/rhcos.go
+++ b/pkg/imageprovider/rhcos.go
@@ -40,7 +40,7 @@ func (ip *rhcosImageProvider) SupportsFormat(format metal3.ImageFormat) bool {
 func (ip *rhcosImageProvider) buildIgnitionConfig(networkData imageprovider.NetworkData) ([]byte, error) {
 	nmstateData := networkData["nmstate"]
 
-	return ignition.New(nmstateData,
+	return ignition.New(nmstateData, []byte{},
 		ip.EnvInputs.IronicBaseURL,
 		ip.EnvInputs.IronicAgentImage,
 		ip.EnvInputs.IronicAgentPullSecret,

--- a/test/registries.conf
+++ b/test/registries.conf
@@ -1,0 +1,7 @@
+[[registry]]
+  prefix = ""
+  location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+  mirror-by-digest-only = true
+
+  [[registry.mirror]]
+    location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"


### PR DESCRIPTION
We need to specify a registries.conf file to set up the mirror, since the pull secret is for the mirror registry but the IPA image path points to the release image.