### PR TITLE
Bug 2037288: Eliminate unsafe default for ironic agent image

### DIFF
--- a/cmd/static-server/main_test.go
+++ b/cmd/static-server/main_test.go
@@ -50,8 +50,9 @@ func (f *fakeImageFileSystem) RemoveImage(name string) {}
 func TestLoadStaticNMState(t *testing.T) {
 	fifs := &fakeImageFileSystem{imagesServed: []string{}}
 	env := &env.EnvInputs{
-		DeployISO:     "foo.iso",
-		IronicBaseURL: "http://example.com",
+		DeployISO:        "foo.iso",
+		IronicBaseURL:    "http://example.com",
+		IronicAgentImage: "quay.io/tantsur/ironic-agent",
 	}
 	if err := loadStaticNMState(env, "../../test/data", fifs); err != nil {
 		t.Errorf("loadStaticNMState() error = %v", err)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -11,7 +11,7 @@ type EnvInputs struct {
 	DeployISO             string `envconfig:"DEPLOY_ISO" required:"true"`
 	DeployInitrd          string `envconfig:"DEPLOY_INITRD" required:"true"`
 	IronicBaseURL         string `envconfig:"IRONIC_BASE_URL" required:"true"`
-	IronicAgentImage      string `envconfig:"IRONIC_AGENT_IMAGE"`
+	IronicAgentImage      string `envconfig:"IRONIC_AGENT_IMAGE" required:"true"`
 	IronicAgentPullSecret string `envconfig:"IRONIC_AGENT_PULL_SECRET"`
 	IronicRAMDiskSSHKey   string `envconfig:"IRONIC_RAMDISK_SSH_KEY"`
 	RegistriesConfPath    string `envconfig:"REGISTRIES_CONF_PATH"`

--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -28,11 +28,6 @@ type ignitionBuilder struct {
 }
 
 func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey string) *ignitionBuilder {
-	if ironicAgentImage == "" {
-		// https://github.com/openshift/ironic-image/blob/master/scripts/configure-coreos-ipa#L13
-		ironicAgentImage = "quay.io/dtantsur/ironic-agent" // TODO check
-	}
-
 	return &ignitionBuilder{
 		nmStateData:           nmStateData,
 		registriesConf:        registriesConf,
@@ -44,6 +39,9 @@ func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ir
 }
 
 func (b *ignitionBuilder) Generate() ([]byte, error) {
+	if b.ironicAgentImage == "" {
+		return nil, errors.New("ironicAgentImage is required")
+	}
 	if b.ironicBaseURL == "" {
 		return nil, errors.New("ironicBaseURL is required")
 	}


### PR DESCRIPTION
We never want to source this image from quay.io/dtantsur in the real
world, so require it to be specified explicitly.