### PR TITLE
Fix fatal Imagehandler crash

### DIFF
--- a/pkg/imagehandler/imagehandler.go
+++ b/pkg/imagehandler/imagehandler.go
@@ -49,6 +49,7 @@ func NewImageHandler(logger logr.Logger, isoFile, initramfsFile, baseURL string)
 		isoFile:       newBaseIso(isoFile),
 		initramfsFile: newBaseInitramfs(initramfsFile),
 		baseURL:       baseURL,
+		keys:          map[string]string{},
 		images:        map[string]*imageFile{},
 		mu:            &sync.Mutex{},
 	}

--- a/pkg/imagehandler/imagehandler_test.go
+++ b/pkg/imagehandler/imagehandler_test.go
@@ -77,3 +77,67 @@ func TestImageHandler(t *testing.T) {
 			rr.Body.String(), expected)
 	}
 }
+
+func TestNewImageHandler(t *testing.T) {
+	handler := NewImageHandler(zap.New(zap.UseDevMode(true)),
+		"dummyfile.iso",
+		"dummyfile.initramfs",
+		"http://base.test:1234")
+
+	ifs := handler.(*imageFileSystem)
+	ifs.isoFile.size = 12345
+	ifs.initramfsFile.size = 12345
+
+	url1, err := handler.ServeImage("test-name-1", []byte{}, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	_, err = handler.ServeImage("test-name-2", []byte{}, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	url1again, err := handler.ServeImage("test-name-1", []byte{}, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	if url1again != url1 {
+		t.Errorf("inconsistent URLs for same key: %s %s", url1, url1again)
+	}
+}
+
+func TestNewImageHandlerStatic(t *testing.T) {
+	handler := NewImageHandler(zap.New(zap.UseDevMode(true)),
+		"dummyfile.iso",
+		"dummyfile.initramfs",
+		"http://base.test:1234")
+
+	ifs := handler.(*imageFileSystem)
+	ifs.isoFile.size = 12345
+	ifs.initramfsFile.size = 12345
+
+	url1, err := handler.ServeImage("test-name-1.iso", []byte{}, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	url2, err := handler.ServeImage("test-name-2.initramfs", []byte{}, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	url1again, err := handler.ServeImage("test-name-1.iso", []byte{}, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	url1Expected := "http://base.test:1234/test-name-1.iso"
+	if url1 != url1Expected {
+		t.Errorf("unexpected url %s (should be %s)", url1, url1Expected)
+	}
+	url2Expected := "http://base.test:1234/test-name-2.initramfs"
+	if url2 != url2Expected {
+		t.Errorf("unexpected url %s (should be %s)", url2, url2Expected)
+	}
+	if url1again != url1 {
+		t.Errorf("inconsistent URLs for same key: %s %s", url1, url1again)
+	}
+}

--- a/pkg/imagehandler/imagehandler_test.go
+++ b/pkg/imagehandler/imagehandler_test.go
@@ -88,21 +88,36 @@ func TestNewImageHandler(t *testing.T) {
 	ifs.isoFile.size = 12345
 	ifs.initramfsFile.size = 12345
 
-	url1, err := handler.ServeImage("test-name-1", []byte{}, false, false)
+	url1, err := handler.ServeImage("test-key-1", []byte{}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	_, err = handler.ServeImage("test-name-2", []byte{}, true, false)
+	url2, err := handler.ServeImage("test-key-2", []byte{}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	url1again, err := handler.ServeImage("test-name-1", []byte{}, false, false)
+
+	name2 := url2[22:]
+	if ifs.imageFileByName(name2) == nil {
+		t.Errorf("can't look up image file \"%s\"", name2)
+	}
+
+	url1again, err := handler.ServeImage("test-key-1", []byte{}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
 
 	if url1again != url1 {
 		t.Errorf("inconsistent URLs for same key: %s %s", url1, url1again)
+	}
+
+	handler.RemoveImage("test-key-1")
+	url1yetagain, err := handler.ServeImage("test-key-1", []byte{}, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if url1yetagain == url1 {
+		t.Errorf("same URLs returned after removal: %s", url1yetagain)
 	}
 }
 


### PR DESCRIPTION
Due to lack of test coverage, an omission meant we cannot call ServeImage without crashing. Fix that and improve test coverage of imagehandler.go