### PR TITLE
Overwrite /etc/containers/registries.conf

### DIFF
--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -73,7 +73,7 @@ func (b *ignitionBuilder) Generate() ([]byte, error) {
 
 	if len(b.registriesConf) > 0 {
 		registriesFile := ignitionFileEmbed("/etc/containers/registries.conf",
-			0644, false,
+			0644, true,
 			b.registriesConf)
 
 		config.Storage.Files = append(config.Storage.Files, registriesFile)

--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -73,7 +73,7 @@ func (b *ignitionBuilder) Generate() ([]byte, error) {
 
 	if len(b.registriesConf) > 0 {
 		registriesFile := ignitionFileEmbed("/etc/containers/registries.conf",
-			0644,
+			0644, false,
 			b.registriesConf)
 
 		config.Storage.Files = append(config.Storage.Files, registriesFile)

--- a/pkg/ignition/file_embed.go
+++ b/pkg/ignition/file_embed.go
@@ -17,10 +17,10 @@ func toDataUrl(text []byte) string {
 	return data.String()
 }
 
-func ignitionFileEmbed(path string, mode int, data []byte) ignition_types.File {
+func ignitionFileEmbed(path string, mode int, overwrite bool, data []byte) ignition_types.File {
 	source := toDataUrl(data)
 	return ignition_types.File{
-		Node: ignition_types.Node{Path: path},
+		Node: ignition_types.Node{Path: path, Overwrite: &overwrite},
 		FileEmbedded1: ignition_types.FileEmbedded1{
 			Contents: ignition_types.Resource{Source: &source},
 			Mode:     &mode,

--- a/pkg/ignition/nmstate.go
+++ b/pkg/ignition/nmstate.go
@@ -23,7 +23,7 @@ func nmstateOutputToFiles(generatedConfig []byte) ([]ignition_config_types_32.Fi
 	for _, v := range networkManagerConfig.NetworkManager {
 		files = append(files,
 			ignitionFileEmbed("/etc/NetworkManager/system-connections/"+v[0],
-				0600,
+				0600, false,
 				[]byte(v[1])))
 	}
 	return files, nil

--- a/pkg/ignition/nmstate_test.go
+++ b/pkg/ignition/nmstate_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestNMStateOutputToFiles(t *testing.T) {
 	expectedMode := 0600
+	expectedOverwrite := false
 	tests := []struct {
 		name            string
 		generatedConfig []byte
@@ -117,7 +118,7 @@ NetworkManager:
 `),
 			want: []ignition_config_types_32.File{
 				{
-					Node: ignition_config_types_32.Node{Path: "/etc/NetworkManager/system-connections/eth1.nmconnection"},
+					Node: ignition_config_types_32.Node{Path: "/etc/NetworkManager/system-connections/eth1.nmconnection", Overwrite: &expectedOverwrite},
 					FileEmbedded1: ignition_config_types_32.FileEmbedded1{
 						Contents: ignition_config_types_32.Resource{
 							Source: pointer.StringPtr("data:text/plain,%5Bconnection%5D%0Aid%3Deth1%0Auuid%3Db6a3fd9a-4c76-4213-a698-8c0f0749b193%0Atype%3Dethernet%0Ainterface-name%3Deth1%0Apermissions%3D%0A%0A%5Bethernet%5D%0Amac-address-blacklist%3D%0A%0A%5Bipv4%5D%0Adhcp-client-id%3Dmac%0Adns-search%3D%0Amethod%3Ddisabled%0A%0A%5Bipv6%5D%0Aaddr-gen-mode%3Deui64%0Adhcp-duid%3Dll%0Adhcp-iaid%3Dmac%0Adns-search%3D%0Amethod%3Ddisabled%0A%0A%5Bproxy%5D%0A")},
@@ -125,7 +126,7 @@ NetworkManager:
 					},
 				},
 				{
-					Node: ignition_config_types_32.Node{Path: "/etc/NetworkManager/system-connections/linux-br0.nmconnection"},
+					Node: ignition_config_types_32.Node{Path: "/etc/NetworkManager/system-connections/linux-br0.nmconnection", Overwrite: &expectedOverwrite},
 					FileEmbedded1: ignition_config_types_32.FileEmbedded1{
 						Contents: ignition_config_types_32.Resource{
 							Source: pointer.StringPtr("data:text/plain,%5Bconnection%5D%0Aid%3Dlinux-br0%0Auuid%3Df942ffa5-668d-41f3-86bd-ef53e35565f4%0Atype%3Dbridge%0Aautoconnect-slaves%3D1%0Ainterface-name%3Dlinux-br0%0Apermissions%3D%0A%0A%5Bbridge%5D%0A%0A%5Bipv4%5D%0Adhcp-client-id%3Dmac%0Adns-search%3D%0Amethod%3Ddisabled%0A%0A%5Bipv6%5D%0Aaddr-gen-mode%3Deui64%0Adhcp-duid%3Dll%0Adhcp-iaid%3Dmac%0Adns-search%3D%0Amethod%3Ddisabled%0A%0A%5Bproxy%5D%0A")},

--- a/pkg/ignition/service_config.go
+++ b/pkg/ignition/service_config.go
@@ -21,7 +21,7 @@ inspection_collectors = default,extra-hardware,logs
 inspection_dhcp_all_interfaces = True
 `
 	contents := fmt.Sprintf(template, b.ironicBaseURL, b.ironicBaseURL, ironicInspectorVlanInterfaces)
-	return ignitionFileEmbed("/etc/ironic-python-agent.conf", 0644, []byte(contents))
+	return ignitionFileEmbed("/etc/ironic-python-agent.conf", 0644, false, []byte(contents))
 }
 
 func (b *ignitionBuilder) ironicAgentService() ignition_config_types_32.Unit {

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestIronicPythonAgentConf(t *testing.T) {
 	expectedMode := 0644
+	expectedOverwrite := false
 	tests := []struct {
 		name                          string
 		ironicBaseURL                 string
@@ -21,7 +22,7 @@ func TestIronicPythonAgentConf(t *testing.T) {
 			name:          "basic",
 			ironicBaseURL: "http://example.com/foo",
 			want: ignition_config_types_32.File{
-				Node: ignition_config_types_32.Node{Path: "/etc/ironic-python-agent.conf"},
+				Node: ignition_config_types_32.Node{Path: "/etc/ironic-python-agent.conf", Overwrite: &expectedOverwrite},
 				FileEmbedded1: ignition_config_types_32.FileEmbedded1{
 					Contents: ignition_config_types_32.Resource{
 						Source: pointer.StringPtr("data:text/plain,%0A%5BDEFAULT%5D%0Aapi_url%20%3D%20http%3A%2F%2Fexample.com%2Ffoo%3A6385%0Ainspection_callback_url%20%3D%20http%3A%2F%2Fexample.com%2Ffoo%3A5050%2Fv1%2Fcontinue%0Ainsecure%20%3D%20True%0A%0Acollect_lldp%20%3D%20True%0Aenable_vlan_interfaces%20%3D%20all%0Ainspection_collectors%20%3D%20default%2Cextra-hardware%2Clogs%0Ainspection_dhcp_all_interfaces%20%3D%20True%0A")},


### PR DESCRIPTION
CoreOS complains about this file already existing, so we have to
overwrite it explicitly.