### PR TITLE
Set IPv6 ClientID and hostname

### DIFF
--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -71,6 +71,15 @@ func (b *ignitionBuilder) Generate() ([]byte, error) {
 		})
 	}
 
+	config.Storage.Files = append(config.Storage.Files, ignitionFileEmbed(
+		"/etc/NetworkManager/conf.d/clientid.conf",
+		0644, false,
+		[]byte("[connection]\nipv6.dhcp-duid=ll\nipv6.dhcp-iaid=mac")))
+	config.Storage.Files = append(config.Storage.Files, ignitionFileEmbed(
+		"/etc/NetworkManager/dispatcher.d/01-hostname",
+		0744, false,
+		[]byte("[[ \"$DHCP6_FQDN_FQDN\" =~ \".\" ]] && hostnamectl set-hostname --static --transient $DHCP6_FQDN_FQDN")))
+
 	if len(b.registriesConf) > 0 {
 		registriesFile := ignitionFileEmbed("/etc/containers/registries.conf",
 			0644, true,


### PR DESCRIPTION
For IPv6, we need to use a stable client ID (based on the MAC) so that
the IP address does not change when we move from IPA to the installed
Node. The Node's IP address must match the one in the inspection data
for Certificate Signing Requests to be approved.

We also need to set the hostname to match the one provided by DHCP,
otherwise it will just be "localhost" in the inspection data, and again
Certificate Signing Requests will not be approved.