### PR TITLE
Bug 2034527: Add IP_OPTIONS environment variable

### DIFF
--- a/cmd/static-server/main.go
+++ b/cmd/static-server/main.go
@@ -63,6 +63,7 @@ func loadStaticNMState(env *env.EnvInputs, nmstateDir string, imageServer imageh
 			env.IronicAgentImage,
 			env.IronicAgentPullSecret,
 			env.IronicRAMDiskSSHKey,
+			env.IpOptions,
 		)
 		if err != nil {
 			return errors.WithMessage(err, "failed to configure ignition")

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -15,6 +15,7 @@ type EnvInputs struct {
 	IronicAgentPullSecret string `envconfig:"IRONIC_AGENT_PULL_SECRET"`
 	IronicRAMDiskSSHKey   string `envconfig:"IRONIC_RAMDISK_SSH_KEY"`
 	RegistriesConfPath    string `envconfig:"REGISTRIES_CONF_PATH"`
+	IpOptions             string `envconfig:"IP_OPTIONS"`
 }
 
 func New() (*EnvInputs, error) {

--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -26,9 +26,10 @@ type ignitionBuilder struct {
 	ironicAgentPullSecret string
 	ironicRAMDiskSSHKey   string
 	networkKeyFiles       []byte
+	ipOptions             string
 }
 
-func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey string) (*ignitionBuilder, error) {
+func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey, ipOptions string) (*ignitionBuilder, error) {
 	if ironicBaseURL == "" {
 		return nil, errors.New("ironicBaseURL is required")
 	}
@@ -43,6 +44,7 @@ func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ir
 		ironicAgentImage:      ironicAgentImage,
 		ironicAgentPullSecret: ironicAgentPullSecret,
 		ironicRAMDiskSSHKey:   ironicRAMDiskSSHKey,
+		ipOptions:             ipOptions,
 	}, nil
 }
 

--- a/pkg/ignition/builder_test.go
+++ b/pkg/ignition/builder_test.go
@@ -18,7 +18,7 @@ func TestGenerateRegistries(t *testing.T) {
 	builder, err := New([]byte{}, []byte(registries),
 		"http://ironic.example.com",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
-		"", "")
+		"", "", "")
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}

--- a/pkg/ignition/service_config.go
+++ b/pkg/ignition/service_config.go
@@ -37,11 +37,11 @@ Wants=network-online.target
 [Service]
 TimeoutStartSec=0
 ExecStartPre=/bin/podman pull %s %s
-ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent %s
+ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env "IPA_COREOS_IP_OPTIONS=%s" --name ironic-agent %s
 [Install]
 WantedBy=multi-user.target
 `
-	contents := fmt.Sprintf(unitTemplate, b.ironicAgentImage, flags, b.ironicAgentImage)
+	contents := fmt.Sprintf(unitTemplate, b.ironicAgentImage, flags, b.ipOptions, b.ironicAgentImage)
 
 	return ignition_config_types_32.Unit{
 		Name:     "ironic-agent.service",

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -56,7 +56,7 @@ func TestIronicAgentService(t *testing.T) {
 			want: ignition_config_types_32.Unit{
 				Name:     "ironic-agent.service",
 				Enabled:  pointer.BoolPtr(true),
-				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
+				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp6\" --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
 			},
 		}}
 	for _, tt := range tests {
@@ -64,6 +64,7 @@ func TestIronicAgentService(t *testing.T) {
 			b := &ignitionBuilder{
 				ironicAgentImage:      tt.ironicAgentImage,
 				ironicAgentPullSecret: tt.ironicAgentPullSecret,
+				ipOptions:             "ip=dhcp6",
 			}
 			if got := b.ironicAgentService(); !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(tt.want, got))

--- a/pkg/imageprovider/rhcos.go
+++ b/pkg/imageprovider/rhcos.go
@@ -53,6 +53,7 @@ func (ip *rhcosImageProvider) buildIgnitionConfig(networkData imageprovider.Netw
 		ip.EnvInputs.IronicAgentImage,
 		ip.EnvInputs.IronicAgentPullSecret,
 		ip.EnvInputs.IronicRAMDiskSSHKey,
+		ip.EnvInputs.IpOptions,
 	)
 	if err != nil {
 		return nil, imageprovider.BuildInvalidError(err)


### PR DESCRIPTION
The IP_OPTIONS we need to use for the provisioned node (which has to
pull its Ignition from the external network) are not necessarily the
same as the ones used for starting IPA (which has to talk to ironic via
the provisioning network if it exists).

Add an environment variable that can be passed down to the custom deploy
step to set the IP options for the installed system via
coreos-installer (in https://github.com/openshift/ironic-agent-image/pull/31).

https://bugzilla.redhat.com/show_bug.cgi?id=2034527