### PR TITLE
Bug 2038303: Handle default_connection

### DIFF
--- a/pkg/ignition/nmstate.go
+++ b/pkg/ignition/nmstate.go
@@ -23,7 +23,7 @@ func nmstateOutputToFiles(generatedConfig []byte) ([]ignition_config_types_32.Fi
 	for _, v := range networkManagerConfig.NetworkManager {
 		files = append(files,
 			ignitionFileEmbed("/etc/NetworkManager/system-connections/"+v[0],
-				0600, false,
+				0600, true,
 				[]byte(v[1])))
 	}
 	return files, nil

--- a/pkg/ignition/nmstate_test.go
+++ b/pkg/ignition/nmstate_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNMStateOutputToFiles(t *testing.T) {
 	expectedMode := 0600
-	expectedOverwrite := false
+	expectedOverwrite := true
 	tests := []struct {
 		name            string
 		generatedConfig []byte

--- a/pkg/ignition/service_config.go
+++ b/pkg/ignition/service_config.go
@@ -24,7 +24,7 @@ inspection_dhcp_all_interfaces = True
 	return ignitionFileEmbed("/etc/ironic-python-agent.conf", 0644, false, []byte(contents))
 }
 
-func (b *ignitionBuilder) ironicAgentService() ignition_config_types_32.Unit {
+func (b *ignitionBuilder) ironicAgentService(copyNetwork bool) ignition_config_types_32.Unit {
 	flags := ironicAgentPodmanFlags
 	if b.ironicAgentPullSecret != "" {
 		flags += " --authfile=/etc/authfile.json"
@@ -41,11 +41,11 @@ Environment="NO_PROXY=%s"
 TimeoutStartSec=0
 Restart=on-failure
 ExecStartPre=/bin/podman pull %s %s
-ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env "IPA_COREOS_IP_OPTIONS=%s" --name ironic-agent %s
+ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env "IPA_COREOS_IP_OPTIONS=%s" --env IPA_COREOS_COPY_NETWORK=%v --name ironic-agent %s
 [Install]
 WantedBy=multi-user.target
 `
-	contents := fmt.Sprintf(unitTemplate, b.httpProxy, b.httpsProxy, b.noProxy, b.ironicAgentImage, flags, b.ipOptions, b.ironicAgentImage)
+	contents := fmt.Sprintf(unitTemplate, b.httpProxy, b.httpsProxy, b.noProxy, b.ironicAgentImage, flags, b.ipOptions, copyNetwork, b.ironicAgentImage)
 
 	return ignition_config_types_32.Unit{
 		Name:     "ironic-agent.service",

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -56,7 +56,7 @@ func TestIronicAgentService(t *testing.T) {
 			want: ignition_config_types_32.Unit{
 				Name:     "ironic-agent.service",
 				Enabled:  pointer.BoolPtr(true),
-				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nEnvironment=\"HTTP_PROXY=\"\nEnvironment=\"HTTPS_PROXY=\"\nEnvironment=\"NO_PROXY=\"\nTimeoutStartSec=0\nRestart=on-failure\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp6\" --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
+				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nEnvironment=\"HTTP_PROXY=\"\nEnvironment=\"HTTPS_PROXY=\"\nEnvironment=\"NO_PROXY=\"\nTimeoutStartSec=0\nRestart=on-failure\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp6\" --env IPA_COREOS_COPY_NETWORK=false --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
 			},
 		}}
 	for _, tt := range tests {
@@ -66,7 +66,7 @@ func TestIronicAgentService(t *testing.T) {
 				ironicAgentPullSecret: tt.ironicAgentPullSecret,
 				ipOptions:             "ip=dhcp6",
 			}
-			if got := b.ironicAgentService(); !reflect.DeepEqual(got, tt.want) {
+			if got := b.ironicAgentService(false); !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(tt.want, got))
 			}
 		})


### PR DESCRIPTION
Allow the user to overwrite the default connection, by setting the 'overwrite' flag on network files and instructing the ironic agent when a network config is present, so that it can ignore only the default connection created by network manager at startup and not one that is created by the user.