### PR TITLE
Bug 2045927: Add proxy for ironic-agent.service

### DIFF
--- a/cmd/static-server/main.go
+++ b/cmd/static-server/main.go
@@ -75,6 +75,9 @@ func loadStaticNMState(fsys fs.FS, env *env.EnvInputs, nmstateDir string, imageS
 			pullSecret,
 			env.IronicRAMDiskSSHKey,
 			env.IpOptions,
+			env.HttpProxy,
+			env.HttpsProxy,
+			env.NoProxy,
 		)
 		if err != nil {
 			return errors.WithMessage(err, "failed to configure ignition")

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -16,6 +16,9 @@ type EnvInputs struct {
 	IronicRAMDiskSSHKey   string `envconfig:"IRONIC_RAMDISK_SSH_KEY"`
 	RegistriesConfPath    string `envconfig:"REGISTRIES_CONF_PATH"`
 	IpOptions             string `envconfig:"IP_OPTIONS"`
+	HttpProxy             string `envconfig:"HTTP_PROXY"`
+	HttpsProxy            string `envconfig:"HTTPS_PROXY"`
+	NoProxy               string `envconfig:"NO_PROXY"`
 }
 
 func New() (*EnvInputs, error) {

--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -27,9 +27,12 @@ type ignitionBuilder struct {
 	ironicRAMDiskSSHKey   string
 	networkKeyFiles       []byte
 	ipOptions             string
+	httpProxy             string
+	httpsProxy            string
+	noProxy               string
 }
 
-func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey, ipOptions string) (*ignitionBuilder, error) {
+func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey, ipOptions, httpProxy, httpsProxy, noProxy string) (*ignitionBuilder, error) {
 	if ironicBaseURL == "" {
 		return nil, errors.New("ironicBaseURL is required")
 	}
@@ -45,6 +48,9 @@ func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ir
 		ironicAgentPullSecret: ironicAgentPullSecret,
 		ironicRAMDiskSSHKey:   ironicRAMDiskSSHKey,
 		ipOptions:             ipOptions,
+		httpProxy:             httpProxy,
+		httpsProxy:            httpsProxy,
+		noProxy:               noProxy,
 	}, nil
 }
 

--- a/pkg/ignition/builder_test.go
+++ b/pkg/ignition/builder_test.go
@@ -18,7 +18,7 @@ func TestGenerateRegistries(t *testing.T) {
 	builder, err := New([]byte{}, []byte(registries),
 		"http://ironic.example.com",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
-		"", "", "")
+		"", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}

--- a/pkg/ignition/service_config.go
+++ b/pkg/ignition/service_config.go
@@ -35,13 +35,16 @@ Description=Ironic Agent
 After=network-online.target
 Wants=network-online.target
 [Service]
+Environment="HTTP_PROXY=%s"
+Environment="HTTPS_PROXY=%s"
+Environment="NO_PROXY=%s"
 TimeoutStartSec=0
 ExecStartPre=/bin/podman pull %s %s
 ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env "IPA_COREOS_IP_OPTIONS=%s" --name ironic-agent %s
 [Install]
 WantedBy=multi-user.target
 `
-	contents := fmt.Sprintf(unitTemplate, b.ironicAgentImage, flags, b.ipOptions, b.ironicAgentImage)
+	contents := fmt.Sprintf(unitTemplate, b.httpProxy, b.httpsProxy, b.noProxy, b.ironicAgentImage, flags, b.ipOptions, b.ironicAgentImage)
 
 	return ignition_config_types_32.Unit{
 		Name:     "ironic-agent.service",

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -56,7 +56,7 @@ func TestIronicAgentService(t *testing.T) {
 			want: ignition_config_types_32.Unit{
 				Name:     "ironic-agent.service",
 				Enabled:  pointer.BoolPtr(true),
-				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp6\" --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
+				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nEnvironment=\"HTTP_PROXY=\"\nEnvironment=\"HTTPS_PROXY=\"\nEnvironment=\"NO_PROXY=\"\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp6\" --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
 			},
 		}}
 	for _, tt := range tests {

--- a/pkg/imageprovider/rhcos.go
+++ b/pkg/imageprovider/rhcos.go
@@ -54,6 +54,9 @@ func (ip *rhcosImageProvider) buildIgnitionConfig(networkData imageprovider.Netw
 		ip.EnvInputs.IronicAgentPullSecret,
 		ip.EnvInputs.IronicRAMDiskSSHKey,
 		ip.EnvInputs.IpOptions,
+		ip.EnvInputs.HttpProxy,
+		ip.EnvInputs.HttpsProxy,
+		ip.EnvInputs.NoProxy,
 	)
 	if err != nil {
 		return nil, imageprovider.BuildInvalidError(err)


### PR DESCRIPTION
Avoid the issue that ironic agent image cannot be downloaded due to network proxy.

See https://github.com/openshift/installer/issues/5552 for details.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>