### PR TITLE
Set Proxy variables for all systemd services

### DIFF
--- a/cmd/static-server/main.go
+++ b/cmd/static-server/main.go
@@ -76,9 +76,7 @@ func loadStaticNMState(fsys fs.FS, env *env.EnvInputs, nmstateDir string, imageS
 			pullSecret,
 			env.IronicRAMDiskSSHKey,
 			env.IpOptions,
-			env.HttpProxy,
-			env.HttpsProxy,
-			env.NoProxy,
+			env.Proxy,
 			hostname,
 		)
 		if err != nil {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -7,6 +7,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+type ProxyConfig struct {
+	HttpProxy  string `envconfig:"HTTP_PROXY"`
+	HttpsProxy string `envconfig:"HTTPS_PROXY"`
+	NoProxy    string `envconfig:"NO_PROXY"`
+}
+
 type EnvInputs struct {
 	DeployISO             string `envconfig:"DEPLOY_ISO" required:"true"`
 	DeployInitrd          string `envconfig:"DEPLOY_INITRD" required:"true"`
@@ -16,9 +22,7 @@ type EnvInputs struct {
 	IronicRAMDiskSSHKey   string `envconfig:"IRONIC_RAMDISK_SSH_KEY"`
 	RegistriesConfPath    string `envconfig:"REGISTRIES_CONF_PATH"`
 	IpOptions             string `envconfig:"IP_OPTIONS"`
-	HttpProxy             string `envconfig:"HTTP_PROXY"`
-	HttpsProxy            string `envconfig:"HTTPS_PROXY"`
-	NoProxy               string `envconfig:"NO_PROXY"`
+	Proxy                 ProxyConfig
 }
 
 func New() (*EnvInputs, error) {

--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -10,6 +10,8 @@ import (
 
 	ignition_config_types_32 "github.com/coreos/ignition/v2/config/v3_2/types"
 	vpath "github.com/coreos/vcontext/path"
+
+	"github.com/openshift/image-customization-controller/pkg/env"
 )
 
 const (
@@ -29,13 +31,11 @@ type ignitionBuilder struct {
 	ironicRAMDiskSSHKey   string
 	networkKeyFiles       []byte
 	ipOptions             string
-	httpProxy             string
-	httpsProxy            string
-	noProxy               string
+	proxy                 env.ProxyConfig
 	hostname              string
 }
 
-func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey, ipOptions string, httpProxy, httpsProxy, noProxy string, hostname string) (*ignitionBuilder, error) {
+func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey, ipOptions string, proxy env.ProxyConfig, hostname string) (*ignitionBuilder, error) {
 	if ironicBaseURL == "" {
 		return nil, errors.New("ironicBaseURL is required")
 	}
@@ -51,9 +51,7 @@ func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ir
 		ironicAgentPullSecret: ironicAgentPullSecret,
 		ironicRAMDiskSSHKey:   ironicRAMDiskSSHKey,
 		ipOptions:             ipOptions,
-		httpProxy:             httpProxy,
-		httpsProxy:            httpsProxy,
-		noProxy:               noProxy,
+		proxy:                 proxy,
 		hostname:              hostname,
 	}, nil
 }
@@ -161,8 +159,8 @@ func (b *ignitionBuilder) defaultEnv() []byte {
 		}
 	}
 
-	setEnv("HTTP_PROXY", b.httpProxy)
-	setEnv("HTTPS_PROXY", b.httpsProxy)
-	setEnv("NO_PROXY", b.noProxy)
+	setEnv("HTTP_PROXY", b.proxy.HttpProxy)
+	setEnv("HTTPS_PROXY", b.proxy.HttpsProxy)
+	setEnv("NO_PROXY", b.proxy.NoProxy)
 	return buf.Bytes()
 }

--- a/pkg/ignition/builder_test.go
+++ b/pkg/ignition/builder_test.go
@@ -3,6 +3,8 @@ package ignition
 import (
 	"strings"
 	"testing"
+
+	"github.com/openshift/image-customization-controller/pkg/env"
 )
 
 func TestGenerateRegistries(t *testing.T) {
@@ -18,7 +20,7 @@ func TestGenerateRegistries(t *testing.T) {
 	builder, err := New([]byte{}, []byte(registries),
 		"http://ironic.example.com",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
-		"", "", "", "", "", "", "virthost")
+		"", "", "", env.ProxyConfig{}, "virthost")
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)
 	}
@@ -38,7 +40,7 @@ func TestDefaultEnv(t *testing.T) {
 	builder, _ := New([]byte{}, []byte{},
 		"http://ironic.example.com",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
-		"", "", "", "", "", "", "virthost")
+		"", "", "", env.ProxyConfig{}, "virthost")
 
 	envConfig := builder.defaultEnv()
 	if string(builder.defaultEnv()) != "[Manager]\n" {
@@ -48,7 +50,11 @@ func TestDefaultEnv(t *testing.T) {
 	builder, _ = New([]byte{}, []byte{},
 		"http://ironic.example.com",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
-		"", "", "", "http.example.com", "https.example.com", "no_proxy.example.com", "virthost")
+		"", "", "", env.ProxyConfig{
+			HttpProxy:  "http.example.com",
+			HttpsProxy: "https.example.com",
+			NoProxy:    "no_proxy.example.com",
+		}, "virthost")
 
 	envConfig = builder.defaultEnv()
 	expected := `[Manager]
@@ -63,7 +69,9 @@ DefaultEnvironment=NO_PROXY="no_proxy.example.com"
 	builder, _ = New([]byte{}, []byte{},
 		"http://ironic.example.com",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
-		"", "", "", "", "https.example.com", "", "virthost")
+		"", "", "", env.ProxyConfig{
+			HttpsProxy: "https.example.com",
+		}, "virthost")
 
 	envConfig = builder.defaultEnv()
 	expected = `[Manager]

--- a/pkg/ignition/service_config.go
+++ b/pkg/ignition/service_config.go
@@ -35,9 +35,6 @@ Description=Ironic Agent
 After=network-online.target
 Wants=network-online.target
 [Service]
-Environment="HTTP_PROXY=%s"
-Environment="HTTPS_PROXY=%s"
-Environment="NO_PROXY=%s"
 TimeoutStartSec=0
 Restart=on-failure
 ExecStartPre=/bin/podman pull %s %s
@@ -45,7 +42,7 @@ ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc
 [Install]
 WantedBy=multi-user.target
 `
-	contents := fmt.Sprintf(unitTemplate, b.httpProxy, b.httpsProxy, b.noProxy, b.ironicAgentImage, flags, b.ipOptions, copyNetwork, b.ironicAgentImage)
+	contents := fmt.Sprintf(unitTemplate, b.ironicAgentImage, flags, b.ipOptions, copyNetwork, b.ironicAgentImage)
 
 	return ignition_config_types_32.Unit{
 		Name:     "ironic-agent.service",

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -61,9 +61,6 @@ Description=Ironic Agent
 After=network-online.target
 Wants=network-online.target
 [Service]
-Environment="HTTP_PROXY="
-Environment="HTTPS_PROXY="
-Environment="NO_PROXY="
 TimeoutStartSec=0
 Restart=on-failure
 ExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -54,9 +54,23 @@ func TestIronicAgentService(t *testing.T) {
 			ironicAgentImage:      "http://example.com/foo:latest",
 			ironicAgentPullSecret: "foo",
 			want: ignition_config_types_32.Unit{
-				Name:     "ironic-agent.service",
-				Enabled:  pointer.BoolPtr(true),
-				Contents: pointer.StringPtr("[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nEnvironment=\"HTTP_PROXY=\"\nEnvironment=\"HTTPS_PROXY=\"\nEnvironment=\"NO_PROXY=\"\nTimeoutStartSec=0\nRestart=on-failure\nExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp6\" --env IPA_COREOS_COPY_NETWORK=false --name ironic-agent http://example.com/foo:latest\n[Install]\nWantedBy=multi-user.target\n"),
+				Name:    "ironic-agent.service",
+				Enabled: pointer.BoolPtr(true),
+				Contents: pointer.StringPtr(`[Unit]
+Description=Ironic Agent
+After=network-online.target
+Wants=network-online.target
+[Service]
+Environment="HTTP_PROXY="
+Environment="HTTPS_PROXY="
+Environment="NO_PROXY="
+TimeoutStartSec=0
+Restart=on-failure
+ExecStartPre=/bin/podman pull http://example.com/foo:latest --tls-verify=false --authfile=/etc/authfile.json
+ExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env "IPA_COREOS_IP_OPTIONS=ip=dhcp6" --env IPA_COREOS_COPY_NETWORK=false --name ironic-agent http://example.com/foo:latest
+[Install]
+WantedBy=multi-user.target
+`),
 			},
 		}}
 	for _, tt := range tests {

--- a/pkg/imageprovider/rhcos.go
+++ b/pkg/imageprovider/rhcos.go
@@ -54,9 +54,7 @@ func (ip *rhcosImageProvider) buildIgnitionConfig(networkData imageprovider.Netw
 		ip.EnvInputs.IronicAgentPullSecret,
 		ip.EnvInputs.IronicRAMDiskSSHKey,
 		ip.EnvInputs.IpOptions,
-		ip.EnvInputs.HttpProxy,
-		ip.EnvInputs.HttpsProxy,
-		ip.EnvInputs.NoProxy,
+		ip.EnvInputs.Proxy,
 		hostname,
 	)
 	if err != nil {


### PR DESCRIPTION
Currently the IPA service is the only one that needs the proxy settings, but in the interests of future flexibility, do [what the installer bootstrap does](https://github.com/openshift/installer/blob/master/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env.conf.template) and set the proxy environment variables by default in all systemd services.