### PR TITLE
Bug 2085721: Create symlink to image-customization-* binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,10 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -a -o bin/image-customizat
 FROM registry.ci.openshift.org/ocp/4.11:base
 COPY --from=builder /go/src/github.com/openshift/image-customization-controller/bin/image-customization-controller /
 COPY --from=builder /go/src/github.com/openshift/image-customization-controller/bin/image-customization-server /
+
+# Binarys have been renamed to machine-image-customization-*, using a symlink for
+# now to ensure backward compat, can be removed at a later stage
+RUN ln -s /image-customization-controller /machine-image-customization-controller
+RUN ln -s /image-customization-server /machine-image-customization-server
+
 RUN dnf install -y nmstate


### PR DESCRIPTION
Binarys are being renamed to machine-image-customization-*,
using a symlink for now to ensure backward compat, can be
removed at a later stage

This will require https://github.com/openshift/installer/pull/5909 before CI passes