### PR TITLE
Support different IP addresses for Inspector and Ironic

### DIFF
--- a/cmd/static-server/main.go
+++ b/cmd/static-server/main.go
@@ -72,6 +72,7 @@ func loadStaticNMState(fsys fs.FS, env *env.EnvInputs, nmstateDir string, imageS
 		hostname := strings.TrimSuffix(f.Name(), path.Ext(f.Name()))
 		igBuilder, err := ignition.New(b, registries,
 			env.IronicBaseURL,
+			env.IronicInspectorBaseURL,
 			env.IronicAgentImage,
 			pullSecret,
 			env.IronicRAMDiskSSHKey,

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -8,17 +8,18 @@ import (
 )
 
 type EnvInputs struct {
-	DeployISO             string `envconfig:"DEPLOY_ISO" required:"true"`
-	DeployInitrd          string `envconfig:"DEPLOY_INITRD" required:"true"`
-	IronicBaseURL         string `envconfig:"IRONIC_BASE_URL"`
-	IronicAgentImage      string `envconfig:"IRONIC_AGENT_IMAGE" required:"true"`
-	IronicAgentPullSecret string `envconfig:"IRONIC_AGENT_PULL_SECRET"`
-	IronicRAMDiskSSHKey   string `envconfig:"IRONIC_RAMDISK_SSH_KEY"`
-	RegistriesConfPath    string `envconfig:"REGISTRIES_CONF_PATH"`
-	IpOptions             string `envconfig:"IP_OPTIONS"`
-	HttpProxy             string `envconfig:"HTTP_PROXY"`
-	HttpsProxy            string `envconfig:"HTTPS_PROXY"`
-	NoProxy               string `envconfig:"NO_PROXY"`
+	DeployISO              string `envconfig:"DEPLOY_ISO" required:"true"`
+	DeployInitrd           string `envconfig:"DEPLOY_INITRD" required:"true"`
+	IronicBaseURL          string `envconfig:"IRONIC_BASE_URL"`
+	IronicInspectorBaseURL string `envconfig:"IRONIC_INSPECTOR_BASE_URL"`
+	IronicAgentImage       string `envconfig:"IRONIC_AGENT_IMAGE" required:"true"`
+	IronicAgentPullSecret  string `envconfig:"IRONIC_AGENT_PULL_SECRET"`
+	IronicRAMDiskSSHKey    string `envconfig:"IRONIC_RAMDISK_SSH_KEY"`
+	RegistriesConfPath     string `envconfig:"REGISTRIES_CONF_PATH"`
+	IpOptions              string `envconfig:"IP_OPTIONS"`
+	HttpProxy              string `envconfig:"HTTP_PROXY"`
+	HttpsProxy             string `envconfig:"HTTPS_PROXY"`
+	NoProxy                string `envconfig:"NO_PROXY"`
 }
 
 func New() (*EnvInputs, error) {

--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -20,40 +20,45 @@ const (
 )
 
 type ignitionBuilder struct {
-	nmStateData           []byte
-	registriesConf        []byte
-	ironicBaseURL         string
-	ironicAgentImage      string
-	ironicAgentPullSecret string
-	ironicRAMDiskSSHKey   string
-	networkKeyFiles       []byte
-	ipOptions             string
-	httpProxy             string
-	httpsProxy            string
-	noProxy               string
-	hostname              string
+	nmStateData            []byte
+	registriesConf         []byte
+	ironicBaseURL          string
+	ironicInspectorBaseURL string
+	ironicAgentImage       string
+	ironicAgentPullSecret  string
+	ironicRAMDiskSSHKey    string
+	networkKeyFiles        []byte
+	ipOptions              string
+	httpProxy              string
+	httpsProxy             string
+	noProxy                string
+	hostname               string
 }
 
-func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey, ipOptions string, httpProxy, httpsProxy, noProxy string, hostname string) (*ignitionBuilder, error) {
+func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicInspectorBaseURL, ironicAgentImage, ironicAgentPullSecret, ironicRAMDiskSSHKey, ipOptions string, httpProxy, httpsProxy, noProxy string, hostname string) (*ignitionBuilder, error) {
 	if ironicBaseURL == "" {
 		return nil, errors.New("ironicBaseURL is required")
+	}
+	if ironicInspectorBaseURL == "" {
+		ironicInspectorBaseURL = ironicBaseURL
 	}
 	if ironicAgentImage == "" {
 		return nil, errors.New("ironicAgentImage is required")
 	}
 
 	return &ignitionBuilder{
-		nmStateData:           nmStateData,
-		registriesConf:        registriesConf,
-		ironicBaseURL:         ironicBaseURL,
-		ironicAgentImage:      ironicAgentImage,
-		ironicAgentPullSecret: ironicAgentPullSecret,
-		ironicRAMDiskSSHKey:   ironicRAMDiskSSHKey,
-		ipOptions:             ipOptions,
-		httpProxy:             httpProxy,
-		httpsProxy:            httpsProxy,
-		noProxy:               noProxy,
-		hostname:              hostname,
+		nmStateData:            nmStateData,
+		registriesConf:         registriesConf,
+		ironicBaseURL:          ironicBaseURL,
+		ironicInspectorBaseURL: ironicInspectorBaseURL,
+		ironicAgentImage:       ironicAgentImage,
+		ironicAgentPullSecret:  ironicAgentPullSecret,
+		ironicRAMDiskSSHKey:    ironicRAMDiskSSHKey,
+		ipOptions:              ipOptions,
+		httpProxy:              httpProxy,
+		httpsProxy:             httpsProxy,
+		noProxy:                noProxy,
+		hostname:               hostname,
 	}, nil
 }
 

--- a/pkg/ignition/builder_test.go
+++ b/pkg/ignition/builder_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGenerateStructure(t *testing.T) {
 	builder, err := New(nil, nil,
-		"http://ironic.example.com",
+		"http://ironic.example.com", "",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
 		"", "", "", "", "", "", "")
 	assert.NoError(t, err)
@@ -24,13 +24,14 @@ func TestGenerateStructure(t *testing.T) {
 
 	// Sanity-check only
 	assert.Contains(t, *ignition.Systemd.Units[0].Contents, "ironic-agent")
-	assert.Contains(t, *ignition.Storage.Files[0].Contents.Source, "ironic.example.com")
+	assert.Contains(t, *ignition.Storage.Files[0].Contents.Source, "ironic.example.com%3A6385")
+	assert.Contains(t, *ignition.Storage.Files[0].Contents.Source, "ironic.example.com%3A5050")
 	assert.Equal(t, ignition.Storage.Files[1].Path, "/etc/NetworkManager/conf.d/clientid.conf")
 }
 
 func TestGenerateWithMoreFields(t *testing.T) {
 	builder, err := New(nil, []byte("I am registry"),
-		"http://ironic.example.com",
+		"http://ironic.example.com", "http://inspector.example.com",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
 		"pull secret", "SSH key", "ip=dhcp42",
 		"proxy me", "", "don't proxy me", "my-host")
@@ -46,7 +47,8 @@ func TestGenerateWithMoreFields(t *testing.T) {
 
 	// Sanity-check only
 	assert.Contains(t, *ignition.Systemd.Units[0].Contents, "ironic-agent")
-	assert.Contains(t, *ignition.Storage.Files[0].Contents.Source, "ironic.example.com")
+	assert.Contains(t, *ignition.Storage.Files[0].Contents.Source, "ironic.example.com%3A6385")
+	assert.Contains(t, *ignition.Storage.Files[0].Contents.Source, "inspector.example.com%3A5050")
 	assert.Equal(t, ignition.Storage.Files[1].Path, "/etc/authfile.json")
 	assert.Equal(t, ignition.Storage.Files[2].Path, "/etc/NetworkManager/conf.d/clientid.conf")
 	assert.Equal(t, ignition.Storage.Files[3].Path, "/etc/NetworkManager/dispatcher.d/01-hostname")
@@ -66,7 +68,7 @@ func TestGenerateRegistries(t *testing.T) {
     location = "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
 `
 	builder, err := New([]byte{}, []byte(registries),
-		"http://ironic.example.com",
+		"http://ironic.example.com", "",
 		"quay.io/openshift-release-dev/ironic-ipa-image",
 		"", "", "", "", "", "", "virthost")
 	if err != nil {

--- a/pkg/ignition/service_config.go
+++ b/pkg/ignition/service_config.go
@@ -16,7 +16,7 @@ inspection_callback_url = %s:5050/v1/continue
 insecure = True
 enable_vlan_interfaces = %s
 `
-	contents := fmt.Sprintf(template, b.ironicBaseURL, b.ironicBaseURL, ironicInspectorVlanInterfaces)
+	contents := fmt.Sprintf(template, b.ironicBaseURL, b.ironicInspectorBaseURL, ironicInspectorVlanInterfaces)
 	return ignitionFileEmbed("/etc/ironic-python-agent.conf", 0644, false, []byte(contents))
 }
 

--- a/pkg/ignition/service_config_test.go
+++ b/pkg/ignition/service_config_test.go
@@ -15,17 +15,19 @@ func TestIronicPythonAgentConf(t *testing.T) {
 	tests := []struct {
 		name                          string
 		ironicBaseURL                 string
+		ironicInspectorBaseURL        string
 		ironicInspectorVlanInterfaces string
 		want                          ignition_config_types_32.File
 	}{
 		{
-			name:          "basic",
-			ironicBaseURL: "http://example.com/foo",
+			name:                   "basic",
+			ironicBaseURL:          "http://example.com/foo",
+			ironicInspectorBaseURL: "http://example.com/bar",
 			want: ignition_config_types_32.File{
 				Node: ignition_config_types_32.Node{Path: "/etc/ironic-python-agent.conf", Overwrite: &expectedOverwrite},
 				FileEmbedded1: ignition_config_types_32.FileEmbedded1{
 					Contents: ignition_config_types_32.Resource{
-						Source: pointer.StringPtr("data:text/plain,%0A%5BDEFAULT%5D%0Aapi_url%20%3D%20http%3A%2F%2Fexample.com%2Ffoo%3A6385%0Ainspection_callback_url%20%3D%20http%3A%2F%2Fexample.com%2Ffoo%3A5050%2Fv1%2Fcontinue%0Ainsecure%20%3D%20True%0Aenable_vlan_interfaces%20%3D%20all%0A")},
+						Source: pointer.StringPtr("data:text/plain,%0A%5BDEFAULT%5D%0Aapi_url%20%3D%20http%3A%2F%2Fexample.com%2Ffoo%3A6385%0Ainspection_callback_url%20%3D%20http%3A%2F%2Fexample.com%2Fbar%3A5050%2Fv1%2Fcontinue%0Ainsecure%20%3D%20True%0Aenable_vlan_interfaces%20%3D%20all%0A")},
 					Mode: &expectedMode},
 			},
 		},
@@ -33,7 +35,8 @@ func TestIronicPythonAgentConf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := &ignitionBuilder{
-				ironicBaseURL: tt.ironicBaseURL,
+				ironicBaseURL:          tt.ironicBaseURL,
+				ironicInspectorBaseURL: tt.ironicInspectorBaseURL,
 			}
 			if got := b.IronicAgentConf(); !reflect.DeepEqual(got, tt.want) {
 				t.Error(cmp.Diff(tt.want, got))

--- a/pkg/imageprovider/rhcos.go
+++ b/pkg/imageprovider/rhcos.go
@@ -50,6 +50,7 @@ func (ip *rhcosImageProvider) buildIgnitionConfig(networkData imageprovider.Netw
 
 	builder, err := ignition.New(nmstateData, ip.RegistriesConf,
 		ip.EnvInputs.IronicBaseURL,
+		ip.EnvInputs.IronicInspectorBaseURL,
 		ip.EnvInputs.IronicAgentImage,
 		ip.EnvInputs.IronicAgentPullSecret,
 		ip.EnvInputs.IronicRAMDiskSSHKey,


### PR DESCRIPTION
As part of the ironic-proxy work, Ironic will be proxied through the API
VIP, while Inspector will work as before.
