### PR TITLE
OCPBUGS-4465: Log message if nmstate output is '--- {}\n'

### DIFF
--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -73,6 +73,9 @@ func (b *ignitionBuilder) ProcessNetworkState() (error, string) {
 			}
 			return err, ""
 		}
+		if string(out) == "--- {}\n" {
+			return nil, "no network configuration"
+		}
 		b.networkKeyFiles = out
 	}
 	return nil, ""


### PR DESCRIPTION
Even if the nmstate data is incorrect,  the metal3 customized image builds and boots up without the network.
```bash
$ oc rsh metal3-image-customization-76ccc78d59-wzjm7
sh-4.4# cat << EOF | nmstatectl gc -
foo:
  bar: baz
EOF
--- {}
```