### PR TITLE
Fix to work with rust-based nmstatectl

### DIFF
--- a/pkg/ignition/builder.go
+++ b/pkg/ignition/builder.go
@@ -64,7 +64,7 @@ func New(nmStateData, registriesConf []byte, ironicBaseURL, ironicInspectorBaseU
 
 func (b *ignitionBuilder) ProcessNetworkState() (error, string) {
 	if len(b.nmStateData) > 0 {
-		nmstatectl := exec.Command("nmstatectl", "gc", "-")
+		nmstatectl := exec.Command("nmstatectl", "gc", "/dev/stdin")
 		nmstatectl.Stdin = strings.NewReader(string(b.nmStateData))
 		out, err := nmstatectl.Output()
 		if err != nil {
@@ -81,7 +81,7 @@ func (b *ignitionBuilder) ProcessNetworkState() (error, string) {
 func (b *ignitionBuilder) GenerateConfig() (config ignition_config_types_32.Config, err error) {
 	netFiles := []ignition_config_types_32.File{}
 	if len(b.nmStateData) > 0 {
-		nmstatectl := exec.Command("nmstatectl", "gc", "-")
+		nmstatectl := exec.Command("nmstatectl", "gc", "/dev/stdin")
 		nmstatectl.Stdin = strings.NewReader(string(b.nmStateData))
 		out, err := nmstatectl.Output()
 		if err != nil {


### PR DESCRIPTION
The python nmstatectl command was replaced with one written in rust (starting with version 2.1.0 of NMState, although it was available as an option since 2.0.0). The new version does not accept '-' as a filename argument to mean stdin, so we have to be more explicit.