### PR TITLE
Ensure consistent URLs if the content is the same

### DIFF
--- a/pkg/imagehandler/basefile.go
+++ b/pkg/imagehandler/basefile.go
@@ -1,19 +1,26 @@
 package imagehandler
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
 	"os"
+
+	"github.com/pkg/errors"
 
 	"github.com/openshift/assisted-image-service/pkg/isoeditor"
 )
 
 type baseFile interface {
 	Size() (int64, error)
+	CheckSum() (string, error)
 	InsertIgnition(*isoeditor.IgnitionContent) (isoeditor.ImageReader, error)
 }
 
 type baseFileData struct {
 	filename string
 	size     int64
+	checkSum string
 }
 
 func (bf *baseFileData) Size() (int64, error) {
@@ -25,6 +32,24 @@ func (bf *baseFileData) Size() (int64, error) {
 		bf.size = fi.Size()
 	}
 	return bf.size, nil
+}
+
+func (bf *baseFileData) CheckSum() (string, error) {
+	if bf.checkSum == "" {
+		fp, err := os.Open(bf.filename)
+		if err != nil {
+			return "", err
+		}
+		defer fp.Close()
+
+		hash := sha256.New()
+		if _, err := io.Copy(hash, fp); err != nil {
+			return "", errors.Wrapf(err, "cannot calculate checksum for %s", bf.filename)
+		}
+
+		bf.checkSum = hex.EncodeToString(hash.Sum(nil))
+	}
+	return bf.checkSum, nil
 }
 
 type baseIso struct {

--- a/pkg/imagehandler/imagefilesystem.go
+++ b/pkg/imagehandler/imagefilesystem.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
-	"path"
 	"time"
 )
 
@@ -52,7 +51,7 @@ func (f *imageFileSystem) Open(name string) (http.File, error) {
 		return f, nil
 	}
 
-	im := f.imageFileByName(path.Base(name))
+	im := f.imageFileByName(name)
 	if im == nil {
 		return nil, fs.ErrNotExist
 	}


### PR DESCRIPTION
Currently, all URLs use a random UUID, so that a URL for a host changes
when the controller is restarted. It only works well, because the BMH
controller does not track URL changes.

To enable the BMH controller to make decisions based on URLs, this
change switches to stable URLs formed as:

    /<sha256 of the base image>/<sha256 of ignition>

This way, the URL only changes if the base image is updated (e.g. on OCP
upgrade) or new Ignition is used.
