### PR TITLE
OCPBUGS-13532: Respond to changes in Secrets

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -37,6 +37,7 @@ import (
 
 	metal3iov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	metal3iocontroller "github.com/metal3-io/baremetal-operator/controllers/metal3.io"
+	"github.com/metal3-io/baremetal-operator/pkg/secretutils"
 	"github.com/openshift/image-customization-controller/pkg/env"
 	"github.com/openshift/image-customization-controller/pkg/imagehandler"
 	"github.com/openshift/image-customization-controller/pkg/imageprovider"
@@ -81,11 +82,11 @@ func runController(watchNamespace string, imageServer imagehandler.ImageHandler,
 	}
 
 	cacheOptions := cache.Options{
-		SelectorsByObject: cache.SelectorsByObject{
+		SelectorsByObject: secretutils.AddSecretSelector(cache.SelectorsByObject{
 			&metal3iov1alpha1.PreprovisioningImage{}: cache.ObjectSelector{
 				Label: labels.NewSelector().Add(*excludeInfraEnv),
 			},
-		},
+		}),
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{


### PR DESCRIPTION
Secrets were not being cached, so we never noticed if they changed. If the user modified a Secret the PreprovisioningImage would not be updated, and baremetal-operator would refuse to accept it (since it wouldn't match the latest version).

This was already implemented by
68cc920efd5842645c944d8dce04c4e2d9a08a38, but that change was accidentally dropped almost immediately after, in a rebase of what became 2413b14eeb6f1ea808a0a0a6aae68b55e1979825 and b5cac5bf0ae0d0172c1d15cf58efba73b245401a, and nobody noticed.