### PR TITLE
METAL-1509: Add support for multi arch image files

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -169,7 +169,11 @@ func main() {
 		envInputs.IronicAgentPullSecret = string(pullSecretRaw)
 	}
 
-	imageServer := imagehandler.NewImageHandler(ctrl.Log.WithName("ImageHandler"), envInputs.DeployISO, envInputs.DeployInitrd, publishURL)
+	imageServer, err := imagehandler.NewImageHandler(ctrl.Log.WithName("ImageHandler"), publishURL, envInputs)
+	if err != nil {
+		setupLog.Error(err, "failed to initialized image handler")
+		os.Exit(1)
+	}
 	http.Handle("/", http.FileServer(imageServer.FileSystem()))
 
 	go func() {

--- a/cmd/static-server/main_test.go
+++ b/cmd/static-server/main_test.go
@@ -42,7 +42,7 @@ func (f *fakeImageFileSystem) Seek(offset int64, whence int) (int64, error) { re
 func (f *fakeImageFileSystem) Readdir(n int) ([]fs.FileInfo, error)         { return nil, nil }
 func (f *fakeImageFileSystem) Open(name string) (http.File, error)          { return nil, nil }
 func (f *fakeImageFileSystem) FileSystem() http.FileSystem                  { return f }
-func (f *fakeImageFileSystem) ServeImage(name string, ignitionContent []byte, initrd, static bool) (string, error) {
+func (f *fakeImageFileSystem) ServeImage(name string, arch string, ignitionContent []byte, initrd, static bool) (string, error) {
 	f.imagesServed = append(f.imagesServed, name)
 	return "", nil
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -10,6 +10,7 @@ import (
 type EnvInputs struct {
 	DeployISO                 string `envconfig:"DEPLOY_ISO" required:"true"`
 	DeployInitrd              string `envconfig:"DEPLOY_INITRD" required:"true"`
+	ImageSharedDir            string `envconfig:"IMAGE_SHARED_DIR" default:"/shared/html/images"`
 	IronicBaseURL             string `envconfig:"IRONIC_BASE_URL"`
 	IronicInspectorBaseURL    string `envconfig:"IRONIC_INSPECTOR_BASE_URL"`
 	IronicAgentImage          string `envconfig:"IRONIC_AGENT_IMAGE" required:"true"`

--- a/pkg/imagehandler/imagefile.go
+++ b/pkg/imagehandler/imagefile.go
@@ -26,6 +26,7 @@ type imageFile struct {
 	io.ReadSeekCloser
 	name            string
 	size            int64
+	arch            string
 	ignitionContent []byte
 	imageReader     isoeditor.ImageReader
 	initramfs       bool

--- a/pkg/imagehandler/imagefilesystem.go
+++ b/pkg/imagehandler/imagefilesystem.go
@@ -56,7 +56,10 @@ func (f *imageFileSystem) Open(name string) (http.File, error) {
 	if im == nil {
 		return nil, fs.ErrNotExist
 	}
-	if err := im.Init(f.getBaseImage(im.initramfs)); err != nil {
+
+	baseImage := f.getBaseImage(im.arch, im.initramfs)
+
+	if err := im.Init(baseImage); err != nil {
 		f.log.Error(err, "failed to create image stream")
 		return nil, err
 	}

--- a/pkg/imagehandler/imagehandler_test.go
+++ b/pkg/imagehandler/imagehandler_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/openshift/image-customization-controller/pkg/env"
 )
 
 type closer struct {
@@ -47,8 +49,10 @@ func TestImageHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	imageServer := &imageFileSystem{
-		log:     zap.New(zap.UseDevMode(true)),
-		isoFile: &baseIso{baseFileData{filename: "dummyfile.iso", size: 12345}},
+		log: zap.New(zap.UseDevMode(true)),
+		isoFiles: map[string]*baseIso{
+			"host": {baseFileData{filename: "dummyfile.iso", size: 12345}},
+		},
 		baseURL: baseURL,
 		keys: map[string]string{
 			"host-xyz-45-uuid": "host-xyz-45.iso",
@@ -86,20 +90,29 @@ func TestNewImageHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	handler := NewImageHandler(zap.New(zap.UseDevMode(true)),
-		"dummyfile.iso",
-		"dummyfile.initramfs",
-		baseUrl)
 
-	ifs := handler.(*imageFileSystem)
-	ifs.isoFile.size = 12345
-	ifs.initramfsFile.size = 12345
+	ifs := imageFileSystem{
+		baseURL:        baseUrl,
+		keys:           map[string]string{},
+		mu:             &sync.Mutex{},
+		images:         map[string]*imageFile{},
+		isoFiles:       map[string]*baseIso{},
+		initramfsFiles: map[string]*baseInitramfs{},
+	}
 
-	url1, err := handler.ServeImage("test-key-1", []byte{}, false, false)
+	iso := newBaseIso("dummyfile.iso")
+	iso.size = 123456
+	ifs.isoFiles["host"] = iso
+
+	initramfs := newBaseInitramfs("dummyfile.initramfs")
+	initramfs.size = 12345
+	ifs.initramfsFiles["host"] = initramfs
+
+	url1, err := ifs.ServeImage("test-key-1", "", []byte{}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	url2, err := handler.ServeImage("test-key-2", []byte{}, true, false)
+	url2, err := ifs.ServeImage("test-key-2", "", []byte{}, true, false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -109,7 +122,7 @@ func TestNewImageHandler(t *testing.T) {
 		t.Errorf("can't look up image file \"%s\"", name2)
 	}
 
-	url1again, err := handler.ServeImage("test-key-1", []byte{}, false, false)
+	url1again, err := ifs.ServeImage("test-key-1", "", []byte{}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -118,8 +131,8 @@ func TestNewImageHandler(t *testing.T) {
 		t.Errorf("inconsistent URLs for same key: %s %s", url1, url1again)
 	}
 
-	handler.RemoveImage("test-key-1")
-	url1yetagain, err := handler.ServeImage("test-key-1", []byte{}, false, false)
+	ifs.RemoveImage("test-key-1")
+	url1yetagain, err := ifs.ServeImage("test-key-1", "", []byte{}, false, false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -133,24 +146,33 @@ func TestNewImageHandlerStatic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	handler := NewImageHandler(zap.New(zap.UseDevMode(true)),
-		"dummyfile.iso",
-		"dummyfile.initramfs",
-		baseUrl)
 
-	ifs := handler.(*imageFileSystem)
-	ifs.isoFile.size = 12345
-	ifs.initramfsFile.size = 12345
+	ifs := imageFileSystem{
+		baseURL:        baseUrl,
+		keys:           map[string]string{},
+		mu:             &sync.Mutex{},
+		images:         map[string]*imageFile{},
+		isoFiles:       map[string]*baseIso{},
+		initramfsFiles: map[string]*baseInitramfs{},
+	}
 
-	url1, err := handler.ServeImage("test-name-1.iso", []byte{}, false, true)
+	iso := newBaseIso("dummyfile.iso")
+	iso.size = 123456
+	ifs.isoFiles["host"] = iso
+
+	initramfs := newBaseInitramfs("dummyfile.initramfs")
+	initramfs.size = 12345
+	ifs.initramfsFiles["host"] = initramfs
+
+	url1, err := ifs.ServeImage("test-name-1.iso", "", []byte{}, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	url2, err := handler.ServeImage("test-name-2.initramfs", []byte{}, true, true)
+	url2, err := ifs.ServeImage("test-name-2.initramfs", "", []byte{}, true, true)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	url1again, err := handler.ServeImage("test-name-1.iso", []byte{}, false, true)
+	url1again, err := ifs.ServeImage("test-name-1.iso", "", []byte{}, false, true)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -165,5 +187,73 @@ func TestNewImageHandlerStatic(t *testing.T) {
 	}
 	if url1again != url1 {
 		t.Errorf("inconsistent URLs for same key: %s %s", url1, url1again)
+	}
+}
+
+func TestImagePattern(t *testing.T) {
+	envInputs := &env.EnvInputs{
+		DeployISO:    "/shared/ironic-python-agent.iso",
+		DeployInitrd: "/shared/ironic-python-agent.initramfs",
+	}
+
+	tcs := []struct {
+		name     string
+		filename string
+		arch     string
+		iso      bool
+		error    bool
+	}{
+		{
+
+			name:     "host iso",
+			filename: envInputs.DeployISO,
+			arch:     "host",
+			iso:      true,
+		},
+		{
+
+			name:     "host initramfs",
+			filename: envInputs.DeployInitrd,
+			arch:     "host",
+		},
+		{
+
+			name:     "host initramfs absolute path",
+			filename: "/shared/ironic-python-agent.initramfs",
+			arch:     "host",
+		},
+		{
+
+			name:     "aarch64 iso",
+			filename: "ironic-python-agent_aarch64.iso",
+			arch:     "aarch64",
+			iso:      true,
+		},
+		{
+
+			name:     "aarch64 initramfs",
+			filename: "ironic-python-agent_aarch64.initramfs",
+			arch:     "aarch64",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Logf("testing %s", tc.name)
+		ii, err := parseDeployImage(envInputs, tc.filename)
+
+		if err != nil && !tc.error {
+			t.Errorf("got error: %v", err)
+			return
+		}
+
+		if ii.arch != tc.arch {
+			t.Errorf("arch: expected %s but got %s", tc.arch, ii.arch)
+			return
+		}
+
+		if ii.iso != tc.iso {
+			t.Errorf("iso: expected %t but got %t", tc.iso, ii.iso)
+			return
+		}
 	}
 }


### PR DESCRIPTION
When we start, we read the files in the shared directory and load them into a map based on architecture.  Then, when we serve an image, we look at the architecture field in the PreprovisioningImage and look up the respective files.