### PR TITLE
Bug OCPBUGS-98696: Embed IP_OPTIONS kargs in provisioning ISO

### DIFF
--- a/pkg/imagehandler/basefile.go
+++ b/pkg/imagehandler/basefile.go
@@ -49,14 +49,19 @@ func (bf *baseFileData) Size() (int64, error) {
 
 type baseIso struct {
 	baseFileData
+	kargs string
 }
 
-func newBaseIso(filename string) *baseIso {
-	return &baseIso{baseFileData{filename: filename}}
+func newBaseIso(filename string, kargs string) *baseIso {
+	return &baseIso{baseFileData: baseFileData{filename: filename}, kargs: kargs}
 }
 
 func (biso *baseIso) InsertIgnition(ignition *isoeditor.IgnitionContent) (isoeditor.ImageReader, error) {
-	return isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil, nil)
+	var kargsBytes []byte
+	if biso.kargs != "" {
+		kargsBytes = []byte(biso.kargs)
+	}
+	return isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil, kargsBytes)
 }
 
 type baseInitramfs struct {

--- a/pkg/imagehandler/basefile.go
+++ b/pkg/imagehandler/basefile.go
@@ -61,7 +61,14 @@ func (biso *baseIso) InsertIgnition(ignition *isoeditor.IgnitionContent) (isoedi
 	if biso.kargs != "" {
 		kargsBytes = []byte(biso.kargs)
 	}
-	return isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil, kargsBytes)
+	reader, err := isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil, kargsBytes)
+	if err != nil && kargsBytes != nil {
+		// The kargs embed area may already be occupied (e.g. the installer
+		// embedded console= params into this ISO). Fall back to serving the
+		// ISO without kargs modification rather than failing entirely.
+		reader, err = isoeditor.NewRHCOSStreamReader(biso.filename, ignition, nil, nil)
+	}
+	return reader, err
 }
 
 type baseInitramfs struct {

--- a/pkg/imagehandler/imagehandler.go
+++ b/pkg/imagehandler/imagehandler.go
@@ -263,7 +263,7 @@ func NewImageHandler(logger logr.Logger, baseURL *url.URL, envInputs *env.EnvInp
 
 		switch osImage.kind {
 		case imageKindISO:
-			isoFiles[key] = newBaseIso(filePath)
+			isoFiles[key] = newBaseIso(filePath, envInputs.IpOptions)
 		case imageKindInitramfs:
 			initramfsFiles[key] = newBaseInitramfs(filePath)
 		case imageKindKernel:

--- a/pkg/imagehandler/imagehandler_test.go
+++ b/pkg/imagehandler/imagehandler_test.go
@@ -54,7 +54,7 @@ func TestImageHandler(t *testing.T) {
 	imageServer := &imageFileSystem{
 		log: zap.New(zap.UseDevMode(true)),
 		isoFiles: map[streamArchKey]*baseIso{
-			{arch: "host"}: {baseFileData{filename: "dummyfile.iso", size: 12345}},
+			{arch: "host"}: {baseFileData: baseFileData{filename: "dummyfile.iso", size: 12345}},
 		},
 		baseURL: baseURL,
 		keys: map[string]string{
@@ -103,7 +103,7 @@ func TestNewImageHandler(t *testing.T) {
 		initramfsFiles: map[streamArchKey]*baseInitramfs{},
 	}
 
-	iso := newBaseIso("dummyfile.iso")
+	iso := newBaseIso("dummyfile.iso", "")
 	iso.size = 123456
 	ifs.isoFiles[streamArchKey{arch: "host"}] = iso
 
@@ -159,7 +159,7 @@ func TestNewImageHandlerStatic(t *testing.T) {
 		initramfsFiles: map[streamArchKey]*baseInitramfs{},
 	}
 
-	iso := newBaseIso("dummyfile.iso")
+	iso := newBaseIso("dummyfile.iso", "")
 	iso.size = 123456
 	ifs.isoFiles[streamArchKey{arch: "host"}] = iso
 


### PR DESCRIPTION
In OCP 4.22, the installer reuses the bootstrap VM's live ISO as the provisioning ISO served to target bare metal nodes. The bootstrap ISO has console=ttyS0 embedded in its kargs area, which causes lockups on hardware that requires specific serial port configuration (baud rate, parity, etc). Additionally, ip=dhcp — previously embedded by the now-removed copy-metal/extract-machine-os.sh step — is missing.

Pass the IP_OPTIONS environment variable (e.g. "ip=dhcp") as kernel arguments to NewRHCOSStreamReader when serving ISO images. The isoeditor replaces the entire kargs placeholder area in the ISO's GRUB config, so console=ttyS0 is overwritten with ip=dhcp, restoring parity with the 4.21 provisioning ISO kernel command line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ISO image creation now supports passing kernel arguments and IP options into the image stream.

* **Bug Fixes**
  * Improved handling of empty kernel-argument values during ISO image processing, with a fallback to serve the ISO when kernel-argument streaming isn’t available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->